### PR TITLE
incorporate utils for metadata ectraction and TSV formation

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,5 +1,12 @@
 ## ormir-mids dependencies
 - `nibabel`
+- `yaml`
+- `numpy`
+- `pandas`
+- `pydicom`
+- `json`
+
+
 
 ### Optional dependencies
 - `SimpleITK`

--- a/src/ormir_mids/bin/create_mids_tsvs.py
+++ b/src/ormir_mids/bin/create_mids_tsvs.py
@@ -1,0 +1,17 @@
+import logging
+from pathlib import Path
+
+from ..structure.MIDS import create_tsvs
+from ..utils.files import load_yaml
+
+
+if __name__=='__main__':
+
+    data_path = 'data/MRSpineSegChallenge'
+    info_filepath = f'config/data/{Path(data_path).name}.yaml'
+
+    dataset_info = dict(load_yaml(info_filepath)).get("dataset", load_yaml(info_filepath) ) if Path(info_filepath).exists() else dict()
+    if Path(data_path).exists():
+        create_tsvs(data_path, dataset_info= dataset_info)
+    else:
+        logging.info(f'Path {data_path} does not exist')

--- a/src/ormir_mids/bin/create_mids_tsvs.py
+++ b/src/ormir_mids/bin/create_mids_tsvs.py
@@ -1,3 +1,18 @@
+# Copyright (c) Maria Monzon
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file_metadata except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+__author__ = "Maria Monzon"
+__version__ = "0.0.1"
+
 import logging
 from pathlib import Path
 

--- a/src/ormir_mids/bin/dicom2mids.py
+++ b/src/ormir_mids/bin/dicom2mids.py
@@ -1,0 +1,83 @@
+# Copyright (c) Maria Monzon
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file_metadata except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import shutil
+import argparse
+from pathlib import Path
+from subprocess import check_output
+
+# Parse command-line arguments
+parser = argparse.ArgumentParser(description="Convert DICOM files to NIFTI format adopting the BIDS convention")
+parser.add_argument("-d", "--dicomdir", default="./data/SpinalDiseaseDataset/sourcedata", help="Specify the DICOM directory. Default is './data/SpinalDiseaseDataset/sourcedata'")
+parser.add_argument("-b", "--bidsdir", default="./data/SpinalDiseaseDataset", help="Specify the BIDS directory. Default is './data/SpinalDiseaseDataset'")
+parser.add_argument("-p", "--pidp", default="SDD", help="Specify the PIDP value. Default is 'ID'")
+args = parser.parse_args()
+
+# Declare an array with BIDS MRI anatomical modalities suffixes
+MR_ANAT_MODALITIES = "T1w|T2w|T2star|FLAIR|PD|PDT2|inplaneT1"  # localizer"
+
+TMPDIR = os.path.join(args.bidsdir, "nifti")
+os.makedirs(TMPDIR, exist_ok=True)
+
+# Loop through each DICOM directory
+for pdir in [d for d in os.listdir(args.dicomdir) if os.path.isdir(os.path.join(args.dicomdir, d))]:
+    id = re.search(r'\d+', pdir).group()
+    pid = f"{args.pidp}{int(id):04d}"
+    print(" ------------------------------- ")
+    print(f"Processing subject ID {id} into {pid}")
+    print(" ------------------------------- ")
+
+    ses = 1
+
+    for sesid in [os.path.join(os.path.join(args.dicomdir, pdir), d) for d in os.listdir(os.path.join(args.dicomdir, pdir))]:
+        os.makedirs(os.path.join(TMPDIR, f"sub-{pid}", f"ses-{ses}"), exist_ok=True)
+
+        for sid in [os.path.join(sesid, d) for d in os.listdir(sesid) if os.path.isdir(os.path.join(sesid, d))]:
+            # Run dcm2niix and capture its output
+            # -b controls if json file is created
+            # -m creates if a same series is merged
+            # -z compresses the files
+            # -f Creates the filename
+            output = check_output(["dcm2niix", "-b", "n", "-z", "y", "-m", "y", "-f", f"sub-{pid}_ses-{ses}_run-%s_%c", "-o", os.path.join(TMPDIR, f"sub-{pid}", f"ses-{ses}"), sid])
+            # output = check_output(["dcm2niix", "-b", "n", "-z", "y", "-m", "y", "-f", f"sub-{pid}_ses-{ses}_run-%s_echo-%e_%c", "-o", os.path.join(args.bidsdir, f"sub-{pid}", f"ses-{ses}"), sid])
+
+            # Extract the filename from the output assuming the output contains only one converted file
+            filepath = re.search(r'Convert \d+ DICOM as (.+)', output.decode('utf-8')).group(1)
+
+            # Copy the extracted metadata from the dicom directory
+            shutil.copy(os.path.join(sid, os.path.basename(sid) + ".json"), os.path.join(TMPDIR, f"sub-{pid}", f"ses-{ses}", os.path.basename(filepath) + ".json"))
+
+        # Check if the file name matches the Equidistant resampled pattern
+        for file in [f for f in os.listdir(os.path.join(TMPDIR, f"sub-{pid}", f"ses-{ses}")) if f.endswith(".nii.gz") and "Eq_" in f]:
+            new_name = os.path.join(os.path.dirname(os.path.join(TMPDIR, f"sub-{pid}", f"ses-{ses}", file)), file.replace("_vp", "_desc-equidistant_vp"))
+            new_name = new_name.rpartition("_Eq")[0] + ".nii.gz"
+            os.rename(os.path.join(TMPDIR, f"sub-{pid}", f"ses-{ses}", file), new_name)
+
+        # Loop through files in the source directory that match the pattern
+        for file in [f for f in os.listdir(os.path.join(TMPDIR, f"sub-{pid}", f"ses-{ses}")) if f.endswith(".nii.gz") and "mod-MR-" in f]:
+            modality = os.path.basename(file).split("mod-MR-")[1].split(".nii.gz")[0]
+
+            # Check if the modality is in the list of MR_ANAT_MODALITIES
+            if any(re.match(modality, m) for m in MR_ANAT_MODALITIES.split("|")):
+                new_filename = os.path.basename(file).replace(f"mod-MR-{modality}", modality)
+                dirpath = Path(args.bidsdir)/ f"sub-{pid}"/ f"ses-{ses}"/ "mr-anat"
+                dirpath.mkdir(parents=True, exist_ok=True)
+                # os.makedirs(os.path.join(args.bidsdir, f"sub-{pid}", f"ses-{ses:02d}", "mr-anat"), exist_ok=True)
+
+                # Move and rename the file to the target directory
+                shutil.move(str(Path(TMPDIR)/ f"sub-{pid}"/f"ses-{ses}"/file) , str(Path(args.bidsdir)/ f"sub-{pid}"/ f"ses-{ses}"/ "mr-anat"/ new_filename))
+
+                # Move the corresponding JSON file
+                shutil.move((Path(TMPDIR)/ f"sub-{pid}"/f"ses-{ses}", str(file).replace(".nii.gz", ".json")).as_posix(),  str(Path(args.bidsdir)/ f"sub-{pid}"/ f"ses-{ses}"/ "mr-anat"/ new_filename.replace(".nii.gz", ".json") ))
+
+        ses += 1

--- a/src/ormir_mids/bin/dicomdir.py
+++ b/src/ormir_mids/bin/dicomdir.py
@@ -1,0 +1,229 @@
+# Copyright (c) Maria Monzon
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file_metadata except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+import pydicom  # pydicom is using the gdcm package for decompression
+from pathlib import Path
+import argparse
+import SimpleITK as sitk
+from tqdm import tqdm
+import numpy as np
+import re
+import logging
+from pydicom.datadict import keyword_for_tag
+
+from ..mri import CONTRAST_REGEX, modality_approximation, match_mri_modality, search_mri_sequence, \
+    acquisiton_dimension
+from ..mri.orientation import get_imaging_plane, extract_image_plane_from_description, get_view_plane_short
+from ..utils.files import save_json, load_yaml
+from ..utils.strings import remove_nonalphanumeric, remove_special_characters
+
+def save_patient_dicomdir(dir_path: Path,
+                          output_folder: [str, Path],
+                          pid: [str | None] = None,
+                          default: dict = { "Modality": "MR",
+                                            "BodyPartExamined": "SPINE",
+                                            "ProtocolName": "TSE"}):
+
+    """ Function to structure the DICOM files of a patient in a folder.
+    Parameters:
+    -----------
+    dir_path: Path
+        The path to the patient folder
+    output_folder: str or Path
+        The path to the output_mask folder
+    pid: str
+        The patient if want to keep. If none retrieve from the DICOM series header
+    default: dict
+        The default values to use if the DICOM series header is missing
+        default = { "Modality": "MR",
+                    "BodyPartExamined": "SPINE",
+                    "ProtocolName": "TSE"}
+
+    Returns
+    -------
+    series_overview: list
+        A list of dictionaries containing the information of the series
+    changelog: list
+        A list of lists containing the information of the files
+    Examples:
+    ---------
+    changelog = structure_patient_datadir(patient_datadir, PID, source_datafolder, target_datafolder)
+    """
+    reader = sitk.ImageSeriesReader()
+    changelog = []
+
+    print(f'Processing Patient: {dir_path}')
+
+    PID = dir_path.name.replace('-', '') if pid is None else pid.upper()
+
+    for series_dir in np.unique(
+            [fp.parent for fp in dir_path.rglob('*') if fp.is_file() and 'loc' not in fp.parent.name]):
+        series_description = ""
+
+        for series_id in reader.GetGDCMSeriesIDs(str(series_dir)):
+            logging.info(f"Processing Series: {series_id}")
+            df0 = reader.GetGDCMSeriesFileNames(str(series_dir), series_id)[0]
+            ds0 =  pydicom.read_file(str(df0), force=True)
+            try: # Try to get the series information from the dicom metadata
+                patientID = remove_nonalphanumeric(ds0.get("PatientID",
+                                                              f"{PID}")) if pid is None else pid  # dir_path.name
+
+                studyDate = remove_nonalphanumeric(
+                    ds0.get("StudyDate", ds0.get("SeriesDate", ds0.get("AcquisitionDate", " "))))
+                modality = ds0.get("Modality",  default.get("Modality", ""))
+
+                body_part = remove_nonalphanumeric(ds0.get("BodyPartExamined", default.get("BodyPartExamined", "")))
+                body_part = default.get("BodyPartExamined", "").upper() if not body_part else body_part.upper()
+
+
+                image_orientation_patient = ds0.get("ImageOrientationPatient", None)
+
+                view_plane = get_imaging_plane(
+                    image_orientation_patient) if image_orientation_patient else extract_image_plane_from_description(
+                    series_description)
+
+                view_plane = get_view_plane_short(view_plane)
+
+                series_description = ds0.get("SeriesDescription", f"{Path(df0).parent.name}")
+                protocol = match_mri_modality(ds0.get('ProtocolName', default.get("ProtocolName", "")))
+                protocol = match_mri_modality(remove_special_characters(series_description)) if protocol is None else protocol
+                protocol = protocol if protocol is not None else modality_approximation(ds0.get('EchoTime', 0),
+                                                                                        ds0.get('RepetitionTime', 0),
+                                                                                        ds0.get('InversionTime', 0),
+                                                                                        default_sequence="")
+
+                acquisition = ds0.get('MRAcquisitionType', acquisiton_dimension(ds0.get('AcquisitionMatrix', [0, 0, 0, 0])))
+
+                contrast = ""
+                if 'LOC' not in protocol and 'CAL' not in protocol:
+                    s = search_mri_sequence(ds0.get('SequenceName', ds0.get('ProtocolName', '')),
+                                            remove_special_characters(series_description))
+                    acquisition = f"{acquisition}-{s}" if s is not None else acquisition
+
+                if re.match(CONTRAST_REGEX, series_description, re.IGNORECASE):
+                    contrast = f"_ce-{ds0.get('ContrastBolusAgent', '')}_"
+                    protocol = f"{protocol}ce"
+
+                    # ds.SeriesDescription = series_description
+                sn = str(ds.get('SeriesNumber', 0)).zfill(2)
+                series_classification = f"bp-{body_part}_acq-{acquisition}{contrast}_run-{sn}_vp-{view_plane}_mod-{protocol}"
+
+
+                series_fps = []
+                # Make sure only the series id filepaths are read
+                for i, dfp in enumerate(reader.GetGDCMSeriesFileNames(str(series_dir), series_id)):
+                    series_fps += [ str(Path(dfp).relative_to(dir_path.parent))]
+                    # read the file_metadata
+                    ds = pydicom.read_file(str(dfp), force=True)
+                    try:
+                        ds.PatientID = patientID
+                        ds.SeriesDescription = series_description
+                        ds.ImageComments = series_classification
+                        ds.BodyPartExamined = body_part
+
+                        studyInstanceUID = f"{ds.get('StudyInstanceUID', str(ds.get('SeriesNumber')).zfill(3))}"
+                        seriesInstanceUID = f"{ds.get('SeriesInstanceUID', str(ds.get('SeriesNumber', 0)).zfill(3))}"
+                        instanceNumberUID = f"{ds.get('SOPInstanceUID', ds.get('SeriesInstanceUID', series_id))}"  # f"{ds.get('SOPInstanceUID', seriesInstanceUID)}.{str(ds.get('InstanceNumber', i)).zfill(4)}"
+                        fp = Path( output_folder) / patientID / studyInstanceUID / seriesInstanceUID / f"{instanceNumberUID}.dcm"
+                        Path(fp.parent).mkdir(parents=True, exist_ok=True)
+                        ds.save_as(f"{fp}")
+                        logging.info(f"Saved dicom slice in {fp}")
+                        changelog.append([f"{patientID}", f"{studyDate}", seriesInstanceUID, str(dfp), str(fp)])
+                    except:
+                        continue
+
+                ds0.ImageComments= series_classification
+                ds0.BodyPartExamined = body_part
+                ds0.PatientID = patientID
+                ds0.SeriesDescription =  remove_special_characters(series_description)
+
+                # Save Metadata for the whole series in a json file
+                metadata_dict = {
+                    keyword_for_tag(tag): {'tag': tag, 'Value': values.get('Value', ['']), 'vr': values.get('vr', '')}
+                    for tag, values in ds0.to_json_dict().items()}
+                metadata_dict.pop("PixelData")
+                metadata_dict["SourceFilepaths"] = series_fps
+                #metadata_dict["SeriesInfo"] = series_classification
+
+                studyInstanceUID = f"{ds0.get('StudyInstanceUID', str(ds0.get('SeriesNumber')).zfill(3))}"
+                seriesInstanceUID = f"{ds0.get('SeriesInstanceUID', str(ds0.get('SeriesNumber', 0)).zfill(3))}"
+
+                # (Path( output_folder)  / patientID / studyInstanceUID/ seriesInstanceUID).mkdir(parents=True, exist_ok=True)
+                save_json(metadata_dict, f"{seriesInstanceUID}.json",
+                          Path(output_folder) / patientID / studyInstanceUID / seriesInstanceUID)
+
+
+            except:
+                continue
+            logging.info(series_description)
+
+    return changelog
+
+
+def main(rawdata_folder, output_folder, patient_regex, **kwargs):
+    changelog = []
+    Path(output_folder).mkdir(parents=True, exist_ok=True)
+    patient_fpaths = sorted(Path(rawdata_folder).glob(patient_regex))
+    patientUIDs = ["PID"+re.search(r'\d+', p.relative_to(p.parent).as_posix()).group().zfill(3) for p in patient_fpaths  ]
+
+    for i, pf in tqdm(enumerate(patient_fpaths), desc="Processing Files", total=len(patient_fpaths)):
+        logs = save_patient_dicomdir(pf, output_folder, patientUIDs[i], default=kwargs)
+        changelog += logs
+
+    # Save the changelog
+    traceback = pd.DataFrame(changelog, columns=["PID", "StudyDate", "SeriesInstanceUID", "Source", "Target"])
+    traceback.to_csv(Path(output_folder) / "changelog.log", index=False, sep="\t")
+
+
+def args_parser(env_file: str = ".env") -> argparse.Namespace:
+    """ Argument parser for the main script """
+    # Load the environment variables
+
+    parser = argparse.ArgumentParser(description="Organize Raw Dicom and nested data into DICOMDIR format.")
+
+
+    parser.add_argument("-d", "--data_path", type=str, help=" foldername of the dataset",
+                        default=  "data/")
+
+    parser.add_argument("-dn", "--dataset_name", type=str, help="foldername of the dataset",
+                        default= 'DATASET')
+
+    parser.add_argument("-t", "--target_path", type=str, help="Target folder for a processed dataset",
+                        default= "output")
+
+    parser.add_argument("-p", "--patient_regex", type=str, help="foldername of the dataset",
+                        default="*01_MRI/*/")
+
+    parser.add_argument("-c", "--config", type=str, help="config name", default="data")
+    parser.add_argument("-pf", "--params_file", type=str, help="additional params config file", default= "config/params.yaml")
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+
+    # Set the project target_dir, useful for finding various files
+    project_dir = Path(__file__).resolve().parents[1]
+
+    # Loads the arguments
+    args = args_parser()
+
+    # Load the image_data directory value both, from the environment variable or args if missing
+    data_path = args.data_path if args.data_path  else "data"
+    dataset_name = args.dataset_name if args.dataset_name is not None else ' '
+    output_dir = args.target_path
+
+
+    kwargs = load_yaml(args.params_file) if Path(args.params_file).exists() else { "Modality": "MR",
+                                                                                        "BodyPartExamined": "SPINE",
+                                                                                        "ProtocolName": "TSE"}
+    main(Path(data_path) / dataset_name, output_dir, args.patient_regex, **kwargs)

--- a/src/ormir_mids/mri/__init__.py
+++ b/src/ormir_mids/mri/__init__.py
@@ -1,0 +1,21 @@
+from .sequences import modality_approximation, match_mri_modality, search_mri_sequence, acquisiton_dimension
+
+CONTRAST_REGEX = r'(GAD(O|AVIST)?|[+-]?G[AD]*|GAD|[+-]?C|C?[+-]|CONTRAST|P[0O]ST|\d{0,2}(ML|CC)|ENHANCE|DOT|CONTR|INFUSION|INJECT|MINUTE|AFTER|LATE)'
+MRI_MODALITIES_BIDS = [
+    # BIDS MRI modalities: https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html
+    'PDw',
+    'T1w',
+    'T2w',
+    'T2starw',
+    'FLAIR',
+    'PDT2w',
+    'T1rho',
+    'T1map',
+    'T2map',
+    'T2star',
+    'UNIT1', # Homogeneous (flat) T1-weighted MP2RAGE image
+    'inplaneT1',
+    'inplaneT2',
+    'angio',
+]
+

--- a/src/ormir_mids/mri/orientation.py
+++ b/src/ormir_mids/mri/orientation.py
@@ -1,0 +1,232 @@
+
+# Copyright (c) Maria Monzon
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file_metadata except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import nibabel as nib
+import numpy as np
+import SimpleITK as sitk
+
+ # Image Orientation planes and coordinates systems for MRI
+ # Ref: http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.2.html#sect_C.7.6.2.1.1
+ #    [R] - Right - The direction in which X decreases.
+ #    [L] - Left - The  direction in which X increases.
+ #    [A] - Anterior - The  direction in which, Ydecreases.
+ #    [P] - Posterior - The  direction in which Y  increases.
+ #    [I|F] - Feet - The direction in which Z decreases.
+ #    [S|H] - Head - The direction in which Z increases.
+
+
+IMAGING_PLANES = ["SAGITTAL", "CORONAL", "AXIAL"]
+IMAGING_PLANES_DICT = {"AXIAL": "ax", "CORONAL": "cor", "SAGITTAL": "sag",
+                       "AXIAL-OBLIQUE": "ax-obl", "CORONAL-OBLIQUE": "cor-obl", "SAGITTAL-OBLIQUE": "sag-obl"}
+
+ORIENTATION_LABELS = {  'RAS': (('L','R'),('P','A'),('I','S')),
+                        'LPS': (('R','L'),('A','P'),('S','I')),
+                        'LAS': (('R','L'),('S','I'),('A','P')),
+                        'LAI': (('R','L'),('A','P'),('I','S')),
+                        'RPS': (('L','R'),('A','P'),('S','I')),
+                        'RAI': (('L','R'),('A','P'),('I','S')),
+                        'RBD': (('L','R'),('S','I'),('P','A')),
+                        'LBD': (('R','L'),('S','I'),('P','A'))
+                    }
+
+# Get equivalent direction for SITK orientation
+DIRECTIONS = {'RAS':  (-1, 0, 0, 0, -1, 0, 0, 0, 1),
+              'LPS':  (1, 0, 0, 0, 1, 0, 0, 0, 1),
+              'LAS':  (1, 0, 0, 0, -1, 0, 0, 0, 1),
+              'LAI':  (1, 0, 0, 0, -1, 0, 0, 0, -1),
+              'RPS':  (-1, 0, 0, 0, 1, 0, 0, 0, 1),
+              'RAI':  (-1, 0, 0, 0, 1, 0, 0, 0, -1),
+              'RBD':  (-1, 0, 0, 0, 0, 1, 0, -1, 0),
+              'LBD':  (1, 0, 0, 0, 0, 1, 0, -1, 0)}
+
+def get_orientation_codes(image: nib.Nifti1Image) -> str:
+    """ Get the orientation of the image
+    Parameters:
+    ----------
+    image: nib.Nifti1Image
+        image to extract orientations from
+
+    Returns:
+    --------
+    orientations : (N,) tuple[str]
+        labels for axis direction codes for affine Matrix
+    """
+
+    orientations = nib.aff2axcodes(image.affine)
+    return orientations
+
+def get_orientation(image: nib.Nifti1Image) -> str:
+    """ Get the orientation of the image
+    Parameters:
+    ----------
+    image: nib.Nifti1Image
+        image to extract orientations from
+
+    Returns:
+    --------
+    orientation : str
+        orientation of the image
+    """
+
+    orientation = nib.aff2axcodes(image.affine)
+    return ''.join(orientation)
+
+
+def ensure_orientation(image: nib.Nifti1Image, orientation:str= 'RAS') -> nib.Nifti1Image:
+    """ Ensure that the image is in the desired orientation (http://nipy.org/nibabel/image_orientation.html)
+
+    Parameters:
+    ----------
+    image: nib.Nifti1Image
+        image to be processed
+    orientation: srt
+         desired orientation axes: RAS (default),  LPS axes
+
+    Returns:
+    --------
+    image: nib.Nifti1Image
+        image in desired orientation
+    """
+
+    orientation = ORIENTATION_LABELS.get(orientation, ORIENTATION_LABELS['RAS'])
+
+    orientation_codes = nib.aff2axcodes(image.affine)
+    orientations = nib.orientations.axcodes2ornt(orientation_codes, orientation)
+    image_data = image.get_fdata()
+    image_data = nib.apply_orientation(image_data, orientations)
+    image_nib = nib.Nifti1Image(image_data, image.affine, image.header)
+
+    return image_nib
+
+
+def image_to_RAS(image: nib.Nifti1Image) -> nib.Nifti1Image:
+    """ Convert image to RAS orientation
+    Parameters:
+    ----------
+    image: nib.Nifti1Image
+        image to be processed
+    Returns:
+    --------
+    ras_image: nib.Nifti1Image
+        image in RAS orientation
+    """
+    return  nib.as_closest_canonical(image)
+
+
+def get_imaging_plane(image_orientation_patient: list[float], patient_position:str = 'HFS') -> str:
+    """ Helper function to determine the orientation of the MRI scanform the ImageOrientationPatient DICOM Tag.
+    The image_array represents The direction cosines of the first row and the first column with respect to the patient.
+
+    See https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.7.6.2.html#sect_C.7.6.2.1.1
+
+    Parameters:
+    -----------
+    image_orientation_patient: list[float]
+        The direction cosines of the first row and the first column with respect to the patient
+
+    """
+
+    IMAGING_PLANES =  ["SAGITTAL", "CORONAL", "AXIAL"]
+    POSITIONS = {
+        'HFS': (1, 1),  # No change
+        'FFS': (1, -1),  # Flip the AP axis
+        'HFP': (-1, -1)  # Flip both LR and AP axes
+    }
+
+    # Get adjustment factors based on patient position
+    lr, ap = POSITIONS.get(patient_position, (1, 1))  # Default to no change
+
+    # Adjust direction cosines based on patient position
+    image_y = lr*np.array(image_orientation_patient[:3]) #image_orientation_patient[:3])   # image_orientation_patient[:3]
+    image_x = ap*np.array(image_orientation_patient[3:])
+
+    # Compute the cross product of between the volume_data dicom_slice
+    image_z_components = abs(np.cross(image_x, image_y))
+
+    # Retrieve what is the most prominent magnitude. This encodes if the MR is SAGITTAL,CORONAL,AXIAL
+    imaging_plane = IMAGING_PLANES[list(image_z_components).index(max(image_z_components))]
+
+    if not any(component >=0.97  for component in image_z_components):
+        imaging_plane += "-OBLIQUE"
+
+    return imaging_plane
+
+def get_view_plane_short(plane: str) -> str:
+    """ Get the string representation of the plane
+    Parameters:
+    ----------
+    plane: str
+        plane to be converted
+    Returns:
+    --------
+    plane_str: str
+        string representation of the plane
+    """
+
+    return IMAGING_PLANES_DICT.get(plane, "")
+
+
+
+def extract_image_plane_from_description(description: str = ""):
+    """ Helper function to find the ImageOrientationPatient description from the DICOM description tag.
+    Parameters:
+    -----------
+    description: str
+        The DICOM description tag
+    Returns:
+    --------
+    orientation: str
+        The orientation of the volume_data (AXIAL, CORONAL, SAGITTAL)
+    """
+
+    if str(description).find('AX') != -1 or str(description).find('TRA'):
+        orientation = "AXIAL"
+    elif str(description).find('COR') != -1:
+        orientation = "CORONAL"
+    elif str(description).find('SAG') != -1 or str(description).find('LONGIT'):
+        orientation = "SAGITTAL"
+    else:
+        orientation = ""
+
+    return orientation
+
+
+
+def is_coordinate_system_LPS(image_orientation_patient: list[float], patient_position:str = 'HFS' ) -> bool:
+    """
+    Check if the coordinate system of a DICOM file is in LPS format.
+
+    Parameters:
+    ------------
+    image_orientation_patient: list[float]
+        The direction cosines of the first row and the first column with respect to the patient.
+    patient_position: str
+        The position of the patient in the scanner. Default is 'HFS'.
+
+    Returns:
+    ---------
+    is_LPS:
+        The coordinate system of the DICOM file. True if LPS, False otherwise.    """
+    is_LPS = False
+
+    # The direction cosines for the row (x) and column (y) axes
+    cosines_x = image_orientation_patient[:3]
+    cosines_y = image_orientation_patient[3:]
+    # Check if the direction cosines correspond to the LPS coordinate system
+    # In LPS, the x-axis is negative, y-axis is positive, and z-axis is positive
+    if patient_position =='HFS':
+        is_LPS = all([
+            cosines_x[0] < 0, cosines_y[1] > 0,
+            abs(cosines_x[2]) > 0 or abs(cosines_y[2]) > 0  # Check for non-zero z-component
+        ])
+    return is_LPS

--- a/src/ormir_mids/mri/sequences.py
+++ b/src/ormir_mids/mri/sequences.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Maria Monzon, BMDS ETH Zurich
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file_metadata except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+MRI_MODALITIES = {
+    'localizer': {'localizer|localiser|survey|loc\.|\bscout\b|(?=.*plane)(?=.*loc)|(?=.*plane)(?=.*survey)|3-plane|^loc*|Scout|AdjGre|topogram|three_plane_loc|3plane|3_plane|three_plane|POSDISP|POS'},
+    'CAL': {'(?=.*HO)(?=.*shim)|\bHOS\b|_HOS_|.*shim|calibration|calib*'},
+    'BOLD': {'bold|fmri|resting|rest'},
+    'B0': { '(?=.*field)(?=.*map)|(?=.*bias)(?=.*ch)|field|fmap|topup|DISTORTION|se[-_][aprl]{2}$'},
+    'ADC': { '_ADC$|^ADC|isoADC|AvDC|Average_DC|_TRACEW$|APPARENT DIFFUSION|APPARENT DIFFUSION COEFFICIENT'},
+    'FLAIR': { '(?=.*flair)|(?=.*FLAIR)|(?=.*FluidAttenuatedInversionRecovery)|(?=.*CSFSuppressed)|FLUIDATTENUATEDINVERSIONRECOVERY| (?=.*\b{DARK\b)(?=.*\b{FLUID}\b)|FLAIR'},
+    'PDw': {'(\bPD\b)|(_PD_)|(_PD)|(PD_)' },
+    'T2starw': {'(\bT2\*\b)|(_T2\*_)|(_T2\*)|(T2\*_)|(T2\*)|(t2star)|t2starw'},
+    'T1rho': { '(\bT1rho\b)|(_T1rho_)|(_T1rho)|(T1rho_)|^t1rho|_t1rho$|_t1rho_'},
+    'UNIT1': {'MPRAGE|(?i)mprage'},
+    'MRV': {'^mrv|^mrv$|mrv|mrv$'},
+    'MRA': { '^mra|_mra$|_mra_'},
+    'PWI': {'asl|(?=.*blood)(?=.*flow)|(?=.*art)(?=.*spin)|tof|perfusion|angio|cbf|cerebral_blood_flow|cbv|rBV_map|rBF_map|mtt_map|ttp_rgb'},
+    'SWI': {'swi|susceptibility|suscept|swan|Mag images|Mag_images|Pha_images|Pha images|SW'},
+    'DWI': { 'dti|dwi|diff|diffu|ddiffu|diffusion|difusion|(?=.*diff)(?=.*dir)|hardi'},
+    'T2w': {'(?=.t2)|t2w?|ciss|fiesta|haste' },
+    'T1w': {'(?=.t1)|t1w?|(?!.*inplane)(?=.*3d anat)|(?!.*inplane)(?=.*3d)(?=.*bravo)|bravo|spgr|stir'}
+}
+MRI_SEQUENCES_REGEX = {
+    # "STIR": r"(?i)(Turbo[\s\-_]*STIR|Fast[\s\-_]*STIR|STIR)",
+    "MPRAGE": r"(?i)MPRAGE",
+    "PROPELLER": r"(?i)(PROPELLER|BLADE|MultiVane|VANE|RADAR|JET)",
+    "DESPOT1": r"(?i)(DESPOT1|VFA[\s\-_]*T1)",
+    "DESPOT2": r"(?i)(DESPOT2|VFA[\s\-_]*T2)",
+    "FSE": r"(?i)(FAST[\s\-_]*SPIN[\s\-_]*ECHO|TURBO[\s\-_]*SE|FAST[\s\-_]*SE|SSH\-TSE|UFSE|SSTSE|HASTE|SS\-FSE|TSE|CUBE|VISTA|isoFSE|FSE)",
+    "IR": r"(?i)(INVERSION[\s\-_]*RECOVERY|IR[\s\-_]*RSE|IRM|TIRM|Fast[\s\-_]*IR|FSE\-IR|FIR|IR)",
+    "SSGE": r"(?i)(SteadyState[\s\-_]*GE|BFFE|FFE|FISP|MPGR|GRE|TRSG|SSGE)",
+    "SGE": r"(?i)(SPOILED[\s\-_]*GE|FFE|FLASH|SPGR|MPSPGR|RSSG|RF\-spoiled)",
+    "FGE": r"(?i)(FAST[\s\-_]*GE|FFE|TFE|THRIVE|TurboFLASH|VIBE|BRAVO|FGRE|Fast[\s\-_]*SPGR|FMPSPGR|VIBRANT|FAME|LAVA|R\-TFE|T1\-TurboFLASH|FSPGR)",
+    "SE": r"(?i)(SE|SPIN[\s\-_]*ECHO)",
+    "GRE": r"(?i)(FFE|GRE|GE|FE)",
+    "SSFP": r"(?i)(SSFP|FIESTA|TRUEFISP|B\-FFE)",
+    "PC": r"(?i)(PHASE[\s\-_]*CONTRAST|PC)",
+    "TOF": r"(?i)(TIME[\s\-_]*OF[\s\-_]*FLIGHT|TOF)",
+    "EPI": r"(?i)(EPI|EPI[\s\-_]*DWI)",
+}
+
+
+def match_mri_modality(series_description: str):
+    """ Helper function to find the MRI modality from the DICOM description tag.
+    Parameters:
+    -----------
+    series_description: str
+        The DICOM description tag string
+    Returns:
+    --------
+    modality: str
+        The MRI modality (T1, T2, T2*, FLAIR, DWI, BOLD)
+    """
+    modality = None  # Default value
+
+    # Perform regex search for each pattern
+    for mri_mod, mri_params in MRI_MODALITIES.items():
+        pattern = mri_params
+        match = re.search(pattern, series_description, re.IGNORECASE)
+        if match:
+            modality = mri_mod
+            break
+    return modality
+
+def modality_approximation(echo_time: [int, float], repetition_time: [int, float], inversion_time: [int, float],
+                           default_sequence: str = ""):
+    """ Function to approximate sequence to T1, T2 and FLAIR based on Long/short RT ET.
+    References:
+    - https://case.edu/med/neurology/NR/MRI%20Basics.htm
+    - https://www.imaios.com/en/e-mri/nmr-signal-and-mri-contrast/signal-weighting-and-sequences-parameters
+    - https://www.sciencedirect.com/science/article/pii/S2213158219301998
+
+    Parameters:
+    ----------
+    echo_time: [int, float]
+        time [ms] between the middle of the excitation pulse and the peak of the echo produced
+
+    repetition_time:
+        time [ms] between the beginning of a pulse sequence and the beginning of the next pulse sequence.
+
+    inversion_time:
+        time [ms]  between the middle of the inversion pulse and the middle of the excitation pulse
+
+    default_sequence: str
+        The default sequence type to return if no sequence type is found
+    Returns:
+    --------
+    sequence_type: str
+        The sequence type (T1, T2, FLAIR, PD)
+    """
+    sequence_times = {
+        "PD": {"RT": 2000, "ET": 30, "IT": 0},  # PD typically TR = 1000-3000 ms, TE = 10-30 ms
+        "T1": {"RT": 800, "ET": 30, "IT": 0},  # T1 typically TR = 400-2000 ms, TE = 10-30 ms
+        "T2": {"RT": 500, "ET": 50, "IT": 0},  # T2 typically  TR = 500-2000 ms, TE = 10-30 ms
+        "FLAIR": {"RT": 4500, "ET": 114, "IT": 2000},         # FLAIR typically TR = 4000-6000 ms, TE = 90-120 ms, TI = 2000-2500 ms
+        "STIR": {"RT": 2415, "ET": 68, "IT": 160}   # STIR typically TR = 2500 ms, TE =70 ms, TI = 160 ms
+
+    }
+    # Initialize with default sequence specification in case no value is found (FSE)
+    sequence_type = default_sequence
+
+    inversion_time = float(inversion_time) if inversion_time is not None else 0
+    echo_time = float(echo_time) if echo_time is not None else 0
+    repetition_time = float(repetition_time) if repetition_time is not None else 0
+
+    # Approximate sequence type
+    if inversion_time > 250 and repetition_time > 1500:
+        sequence_type = 'FLAIR'
+
+    if inversion_time > 100 and repetition_time > 1500 and repetition_time < 2700 and echo_time < 100:
+        sequence_type = 'STIR'
+
+    elif echo_time < 30 and repetition_time < 800:
+        sequence_type = 'T1w'
+
+    elif echo_time > 50 and repetition_time < 2500:
+        sequence_type = 'T2w'
+
+    elif echo_time < 50 and repetition_time > 1000:
+        sequence_type = 'PDw'
+
+    return sequence_type
+
+
+def search_mri_sequence(sequence_name: str, series_description: str = None) -> str:
+    """
+    Search for a given MRI sequence name in the MRI_SEQUENCES dictionary.
+
+    Parameters:
+    sequence_name (str): The name of the MRI sequence to search for.
+
+    Returns:
+    str: The key of the MRI sequence if found, otherwise 'Sequence not found'.
+    """
+    sequence = None
+    # Perform regex search for each pattern
+
+    for seq, pattern in MRI_SEQUENCES_REGEX.items():
+        # pattern = mri_params['patterns']
+        match = re.search(pattern, series_description.upper(), re.IGNORECASE)
+        if match:
+            sequence = seq.lower()
+            break
+
+
+    if not sequence:
+        for seq, pattern in MRI_SEQUENCES_REGEX.items():
+            #pattern = mri_params['patterns']
+            match = re.search(pattern, sequence_name.upper(), re.IGNORECASE)
+            if match:
+                sequence = seq.lower()
+                break
+
+    return sequence
+
+
+def acquisiton_dimension( acquisition_matrix: list[int]) -> str:
+    """ Function to approximate the acquisition dimension from the acquisition matrix
+    Parameters:
+    ----------
+    acquisition_matrix: list[int]
+        The DICOM tag 'AcquisitionMatrix' (0018,1310) values generally representing
+        [ frequency rows, frequency columns, phase rows, phase columns ]
+    Returns:
+    --------
+    dimension: str
+        The acquisition dimension (2D, 3D)
+    """
+    dimension = '3D'
+    if sum(1 for value in acquisition_matrix if value > 0) >= 2:
+        dimension = '2D'
+    return dimension
+
+
+
+
+

--- a/src/ormir_mids/structure/MIDS.py
+++ b/src/ormir_mids/structure/MIDS.py
@@ -1,0 +1,927 @@
+# Copyright (c) Maria Monzon
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file_metadata except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+__author__ = "Maria Monzon"
+__version__ = "0.1.0"
+
+
+import logging
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+import nibabel as nib
+import pandas as pd
+import numpy as np
+import shutil
+import SimpleITK as sitk
+from ..utils.files import load_json, save_json
+from ..utils.strings import extract_number
+
+
+MR_ANAT_MODALITIES = ["T1w", "T2w", "T2star", "FLAIR", "PD", "PDT2", "inplaneT1"]
+LOC_MOD = ["loc", "localizer*"]
+
+MODALITIES = {
+    "anat" : '|'.join(MR_ANAT_MODALITIES),
+    "loc" : '|'.join(LOC_MOD)
+}
+
+
+PARTICIPANTS_FIELDS = {
+    "participant_id": {
+        "LongName": "Participant ID",
+        "Description": "A unique identifier for each participant in the study.",
+    },
+    "age": {
+        "LongName": "Age",
+        "Description": "The age of the participant in years relative to the date of birth.",
+        "Units": "years",
+    },
+    "sex": {
+        "LongName": "Sex",
+        "Description": "The sex of the participant as reported by the participant.",
+        "Levels": {
+            "M": "male",
+            "F": "female",
+        },
+    },
+    "modalities": {
+        "LongName": "Modalities",
+        "Description": "The imaging modalities used in the study.",
+    },
+    "body_parts": {
+        "LongName": "Body Parts",
+        "Description": "The body parts imaged in the study",
+    },
+}
+
+SESSION_FIELDS = {
+
+    "session_id": {
+        "LongName": "Session ID",
+        "Description": "A unique identifier for each imaging session in the study.",
+    },
+
+    "study_uid": {
+        "LongName": "Study UID",
+        "Description": "A unique identifier for the study that the session belongs to.",
+    },
+    "acquisition_date": {
+        "LongName": "Acquisition Date and Time",
+        "Description": "The date and time when the imaging session was acquired.",
+    },
+    "radiology_report": {
+        "LongName": "Radiology Report",
+        "Description": "A report containing the interpretation and findings of the imaging session by a radiologist.",
+    },
+}
+NIFTY_FIELDS = {
+    'pixdim': "PixelSpacing",
+    'dim': "Dimensions",
+    'sform_code': "CoordinateSystem",
+    'scl_inter': "RescaleIntercept",
+    'scl_slope': "RescaleSlope",
+}
+
+SCANS_MR_FIELDS = {
+    "scan_file": {
+        "LongName": "Scan File",
+        "Description": "The file name of the scan",
+    },
+    "BodyPart": {
+        "LongName": "Body Part Examined Attribute Tag (0018,0015)",
+        "Description": "The part of the body examined in the scan.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/general-series/00180015"
+    },
+    "Modality": {
+        "LongName": "Acquisition Modality (0008,0060)",
+        "Description": "Type of device, process or method that originally acquired ",
+        "TermURL": "https://dicom.innolitics.com/ciods/segmentation/general-series/00080060"
+    },
+    "SeriesDescription": {
+        "LongName": "Series Description (0008,103E)",
+        "Description": "A description of the series.",
+        "TermURL": "https://dicom.innolitics.com/ciods/ct-image/general-series/0008103e"
+    },
+    "SeriesNumber": {
+        "LongName": "Series Number Attribute Tag (0020,0011)",
+        "Description": "A number that identifies the series.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/general-series/00200011"
+    },
+    "PixelSpacing": {
+        "LongName": "Pixel Spacing (0028,0030)",
+        "Description": "Physical distance between the center of each pixel, specified by a numeric pair - adjacent row spacing (delimiter) adjacent column spacing in mm.",
+        "DICOM Tag": "(0028,0030)",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00280030"
+    },
+    "RepetitionTime": {
+        "LongName": "Repetition Time (0018,0080)",
+        "Description": "Time in seconds between the beginning of a pulse sequence and the beginning of the succeeding (identical) pulse sequence.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180080"
+    },
+    "EchoTime": {
+        "LongName": "Echo Time (0018,0081)",
+        "Description": "Time in milliseconds between the middle of the excitation pulse and the peak of the echo produced.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180081"
+    },
+    "InversionTime": {
+        "LongName": "Inversion Time (0018,0082)",
+        "Description": "Time in milliseconds after the inversion pulse.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180082"
+    },
+
+    "SliceThickness": {
+        "LongName": "Slice Thickness (0018,0050)",
+        "Description": "Nominal slice thickness, in mm.",
+        "DICOM Tag": "(0018,0050)",
+        "TermURL": "https://dicom.innolitics.com/ciods/rt-dose/image-plane/00180050"
+    },
+    "SpacingBetweenSlices": {
+        "LongName": "Spacing Between Slices (0018,0088)",
+        "Description": "Spacing between slices, in mm. The spacing is measured from the center-to-center of each slice.",
+        "TermURL": "https://dicom.innolitics.com/ciods/ct-performed-procedure-protocol/performed-ct-reconstruction/00189934/00180088"
+    },
+    "SeriesInstanceUID": {
+        "LongName": "Series Instance UID Attribute Tag (0020,000E)",
+        "Description": "A unique identifier for the series.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/general-series/0020000E"
+    },
+    "MRAcquisitionType": {
+        "LongName": "MR Acquisition Type (0018,0023)",
+        "Description": "Specifies the type of MR acquisition.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180023"
+    },
+    "MagneticFieldStrength": {
+        "LongName": "Magnetic Field Strength Attribute Tag (0018,0087)",
+        "Description": "The strength of the magnetic field in Tesla.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180087"
+    },
+    "ScanningSequence": {
+        "LongName": "Scanning Sequence (0018,0020)",
+        "Description": "Specifies the type of MR scanning sequence used.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180020"
+    },
+    "SequenceVariant": {
+        "LongName": "Sequence Variant (0018,0021)",
+        "Description": "Specifies the variant of the scanning sequence.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180021"
+    },
+    "ScanOptions": {
+        "LongName": "Scan Options (0018,0022)",
+        "Description": "Specifies additional options for the scanning sequence.",
+        "TermURL": "https://dicom.innolitics.com/ciods/ct-image/ct-image/00180022"
+    },
+    "SequenceName": {
+        "LongName": "Sequence Name (0018,0024)",
+        "Description": "User-defined name for the combination of Scanning Sequence and Sequence Variant.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180024"
+    },
+    "SliceEncodingDirection": {
+        "LongName": "Slice Encoding Direction (0018,1312)",
+        "Description": "Direction in which slices are encoded.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00181312"
+    },
+    "FlipAngle": {
+        "LongName": "Flip Angle (0018,1314)",
+        "Description": "Angle in degrees of the excitation pulse.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00181314"
+    },
+    "EchoNumbers": {
+        "LongName": "Echo Numbers (0018,0086)",
+        "Description": "Number of echoes in multi-echo sequences.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180086"
+    },
+    "EchoTrainLength": {
+        "LongName": "Echo Train Length (0018,0091)",
+        "Description": "Number of lines in k-space acquired per excitation per image.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180091"
+    },
+    "ImagedNucleus": {
+        "LongName": "Imaged Nucleus (0018,0085)",
+        "Description": "Nucleus that is resonant at the imaging frequency.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180085"
+    },
+    "ImagingFrequency": {
+        "LongName": "Imaging Frequency (0018,0084)",
+        "Description": "Precession frequency in MHz of the nucleus being addressed.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180084"
+    },
+    "InPlanePhaseEncodingDirection": {
+        "LongName": "In-plane Phase Encoding Direction (0018,1312)",
+        "Description": "The axis of phase encoding with respect to the image.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00181312"
+    },
+    "NumberOfPhaseEncodingSteps": {
+        "LongName": "Number of Phase Encoding Steps (0018,0089)",
+        "Description": "Number of phase encoding steps along the phase encoding direction before Fourier transformation.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180089"
+    },
+    "PercentPhaseFieldOfView": {
+        "LongName": "Percent Phase Field of View (0018,0094)",
+        "Description": "Percentage of the field of view dimension in the phase direction relative to the frequency direction.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180094"
+    },
+    "PercentSampling": {
+        "LongName": "Percent Sampling (0018,0093)",
+        "Description": "Percentage of sampling of data acquired in the frequency direction.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180093"
+    },
+    "PhotometricInterpretation": {
+        "LongName": "Photometric Interpretation (0028,0004)",
+        "Description": "Specifies the intended interpretation of the pixel data.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00280004"
+    },
+    "PixelBandwidth": {
+        "LongName": "Pixel Bandwidth (0018,0095)",
+        "Description": "Bandwidth per pixel in the phase encode direction.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180095"
+    },
+
+    "SAR": {
+        "LongName": "Specific Absorption Rate (0018,1316)",
+        "Description": "Rate at which RF energy is absorbed by the body during an MR procedure.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00181316"
+    },
+    "SamplesPerPixel": {
+        "LongName": "Samples per Pixel (0028,0002)",
+        "Description": "Number of samples (data points) stored for each pixel in the image.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00280002"
+    },
+    "Manufacturer": {
+        "LongName": "Manufacturer (0008,0070)",
+        "Description": "Manufacturer of the equipment that produced the composite instances.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00080070"
+    },
+    "ManufacturerModelName": {
+        "LongName": "Manufacturer's Model Name Attribute Tag (0008,1090)",
+        "Description": "The model name of the imaging equipment.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/general-equipment/00081090"
+    },
+    "ReceiveCoilName": {
+        "LongName": "Receive Coil Name Attribute Tag (0018,1250)",
+        "Description": "The name of the coil that receives the MR signal.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00181250"
+    },
+
+    "TransmitCoilName": {
+        "LongName": "Transmit Coil Name (0018,1251)",
+        "Description": "The name of the coil used in transmission.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00181251"
+    },
+    "PulseSequenceDetails": {
+        "LongName": "Pulse Sequence Details (0018,9005)",
+        "Description": "Provides details about the pulse sequence used in MR imaging.",
+        "TermURL": "https://dicom.innolitics.com/ciods/enhanced-mr-image/mr-pulse-sequence/00189005"
+    },
+
+    "PulseSequenceName": {
+        "LongName": "Pulse Sequence Name Attribute Tag	(0018,9005)",
+        "Description": "Name of the pulse sequence for annotation purposes",
+        "TermURL": "https://dicom.innolitics.com/ciods/enhanced-mr-image/mr-pulse-sequence/00189005"
+    },
+    "SliceTiming": {
+        "LongName": "Slice Timing (0018,0091)",
+        "Description": "Time at which each slice was acquired.",
+        "TermURL": "https://dicom.innolitics.com/ciods/mr-image/mr-image/00180091"
+    },
+    "WindowCenter": {
+        "LongName": "Window Center (0028,1050)",
+        "Description": "The center of the window used for display.",
+        "TermURL": "https://dicom.innolitics.com/ciods/ct-image/voi-lut/00281050"
+    },
+    "WindowWidth": {
+        "LongName": "Window Width (0028,1051)",
+        "Description": "The width of the window used for display.",
+        "TermURL": "https://dicom.innolitics.com/ciods/ct-image/voi-lut/00281051"
+    },
+    "SpecificCharacterSet": {
+        "LongName": "Specific Character Set (0008,0005)",
+        "Description": "Specifies the character set that is used to encode strings in the DICOM dataset.",
+        "TermURL": "https://dicom.innolitics.com/ciods/ct-image/sop-common/00080005"
+    },
+    "SoftwareVersions": {
+        "LongName": "Software Versions (0018,1020)",
+        "Description": "A string that represents the version of the software.",
+        "TermURL": "https://dicom.innolitics.com/ciods/ct-image/general-equipment/00181020"
+    }
+
+}
+participants_header = list(PARTICIPANTS_FIELDS.keys()) # ['participant_id',  'age', 'sex',  'modalities', 'body_parts' ]
+participants_keys = ['PatientID' , 'PatientBirthDate', 'PatientSex', 'Modality', 'BodyPartExamined']
+session_header = list( SESSION_FIELDS.keys())  #['session_id' ,'study_uid', 'acquisition_date' ,'radiology_report']
+sessions_keys = ['StudyInstanceUID', 'AcquisitionDateTime']
+scans_header_mr = list(SCANS_MR_FIELDS.keys())
+scans_header_micr = ['scan_file' ,
+                     'BodyPart',
+                     'SeriesNumber',
+                     'SeriesInstanceUID',
+                     'Manufacturer'
+                     ,'ManufacturerModelName',
+                     'Modality',
+                     'Columns',
+                     'Rows',
+                     'PhotometricInterpretation'
+                     ,'ImagedVolumeHeight',
+                     'ImagedVolumeHeight']
+scans_header_op = ['scan_file',
+                   'BodyPart',
+                   'SeriesNumber',
+                   'SeriesInstanceUID',
+                   'Manufacturer' ,
+                   'ManufacturerModelName',
+                   'Modality',
+                   'Columns' ,
+                   'Rows',
+                   'PhotometricInterpretation',
+                   'Laterality',
+                   'note']
+chunk_pattern = re.compile(r"_chunk-(?P<chunk>\d)+")
+
+def create_dataset_description_json(metadata_dict: dict, output_path:[Path | None] = None, contributors: list = []) -> dict:
+    """Creates a dataset_description.json file from YAML metadata.
+
+    Parameters
+    ----------
+    metadata_dict: dict
+        dictionary with the metadata of the keys:
+        {
+          Name: 'Dataset Name'
+          DatasetType: "raw",
+          Date: "YYYY-MM-DD"                # Date of the dataset creation
+          Version: "1.0"                    # version of the dataset
+          Description: "Basic Description of the dataset in the form "
+          License: "CC BY-NC-SA 4.0"
+          Doi: " " # DOI of the dataset
+          Reference: " Url of the dataset info page"
+          BIDSVersion: "" # BIDS version of the dataset,
+          Authors: [
+            "Author1",
+            "Author2"
+          ]
+          Acknowledgements: "Special thanks to all the contributors of the dataset"
+          Citation: # citation of the dataset in bibtex format
+            - "@misc {id,
+                        author       = { },
+                        title        = { },
+                        month        =  ,
+                        year         =  ,
+                        publisher    = { },
+                        doi          = { },
+                        url          = { }}"
+
+          Download:
+            URL: # list of urls to download the dataset
+              - "https:/XXXXXXXXX?download=1"
+            checksum : # list of checksums for the downloaded files
+            - ""
+            hash_type: ["md5"]
+          Size: 0.25    #Size of the dataset in GB
+          Nfiles: 447   # Number of files in the dataset excluding metadata files
+
+          Modality: "MR"                      # DICOM Modality Attribute
+          ModalityType: [ "T1w", "T2w"]       # BIDS Modality of the data
+          DataType: "anat"
+          Metadata: ["patients.csv", "overview.csv"]  # metadata files
+          Extension: '.mha'                   # extension of the images and labels
+
+          Dimension: [ "3D", "2D"]            # Data Dimension:  MRAcquisitionType
+          CoordinateSystem: ['LPS']           # Image Orientation Attribute
+          ImagePlane: ["sagittal", "axial"]   # MRI acquisition planes
+          #   PatientPosition : ['HFS']   # Image Orientation Attribute
+          BodyPartExamined: ["LSSPINE"]
+
+          # Tags Related to algorithm training
+          Task: "Segmentation"              # Task for which the dataset is used
+          Labels: { "BG": 0,        # labels names and their corresponding values
+                    "L5": 1,
+                    "L4": 2,
+                    "L3": 3,
+                    "L2": 4,
+                    "L1": 5 }
+
+          PathPatterns:
+          - images:  "/images/*"          # pattern to search for images
+          - labels:  "/masks/*"           # pattern to search for labels
+        }
+
+    output_path: Path or None (optional)
+        path to the output file
+
+    """
+
+    dataset_description = {
+        "Name":  metadata_dict.get("Name", ""), #"The mother of all experiments",
+        "BIDSVersion": metadata_dict.get("BIDSVersion", "1.9.0"),
+        "DatasetType": metadata_dict.get("DatasetType", "mids"),
+        "License": metadata_dict.get("License", "CC BY-NC-SA 4.0"),
+        "Authors": metadata_dict.get('Authors', "Author1, Author2"),
+        "Acknowledgements": metadata_dict.get('Acknowledgements', "Special thanks to the contributors of this dataset"),
+        "HowToAcknowledge": f"Please cite the papers",
+        "ReferencesAndLinks": [
+            metadata_dict.get('Reference',  metadata_dict.get('Download', "").get('URL', [""]))
+        ],
+        "DatasetDOI": metadata_dict.get('Doi', "doi: "),
+
+        "GeneratedBy": [
+            {
+                "Name": f"{contributors}",
+                "Version": ""
+            }
+        ],
+        "SourceDatasets": [
+            {
+                "URL": metadata_dict.get( 'Download', {} ).get('URL',  [  metadata_dict.get('Reference', "") ] )[0],
+                "Version": metadata_dict.get('Version', "1.0"),
+            }
+        ]
+    }
+    duplicate_keys = ["Name", "BIDSVersion", "DatasetType", "License", "Authors",
+                      "Acknowledgements", "Funding", "Doi", "PathPatterns"]
+    dataset_description.update({key: value for key, value in metadata_dict.items() if key not in duplicate_keys}
+    )
+
+    if output_path is not None:
+        save_json(dataset_description, Path(output_path)/'dataset_description.json')
+
+    return dataset_description
+
+
+def create_participants_tsv(bids_root_dir, **kwargs):
+    """
+    Creates a participants.tsv file from BIDS directories.
+
+    Parameters:
+    - bids_root_dir: Path to the BIDS root directory.
+    - output_file: Path where the participants.tsv file will be saved.
+    """
+    participants_data = []
+
+    # Iterate over each participant directory in the BIDS root directory
+    for participant_dir in Path(bids_root_dir).glob('sub-*'):
+        participant_id = participant_dir.name
+
+        # Example of extracting participant information
+        # This should be adapted based on how participant information is stored in your dataset
+        age = "n/a"  # Placeholder for age
+        sex = "n/a"  # Placeholder for sex
+        modalities = "n/a"  # Placeholder for modalities
+        body_parts = "n/a"  # Placeholder for body parts
+
+        # Append the participant's information to the list
+        participants_data.append({
+            "participant_id": participant_id,
+            "age": age,
+            "sex": sex,
+            "modalities": modalities,
+            "body_parts": body_parts
+        })
+
+    # Create a DataFrame
+    participants_df = pd.DataFrame(participants_data)
+
+    # Save the DataFrame to a TSV file
+    participants_df.to_csv('participants.tsv', sep='\t', index=False)
+    return participants_df
+
+def create_tsvs(data_path: [Path, str], dataset_info: dict = dict(), radiology_reports_dict: dict = dict() ):
+
+    """
+    Function to create the necessary participants tsv file for bids compliant.
+    # Code adapted from https://github.com/BIMCV-CSUSP/MIDS/blob/main/xnat2mids/mids_conversion.py
+
+    Parameters
+    ----------
+    data_path: Path
+        path to the data
+    info_filepath: Path
+        path to the info file
+
+    radiology_reports_dict: dict (optional= dict())
+        dictionary with the radiology reports
+
+    Returns
+    -------
+    None
+    """
+    data_path = Path(data_path)
+
+    participants_information= []
+    for subject_path in sorted(data_path.glob('sub-*/')):
+        # print(subject_path.name)
+        if not (subject_path.is_dir()):
+            continue
+
+        subject = subject_path.parts[-1]
+        try:
+            subject_id =  re.search(r'\d+', subject).group() # re.findall( r'\d{2,}', subject.split("-")[-1])
+        except:
+            subject_id =  subject.split("-")[-1]
+        sessions_information = []
+        modalities = []
+        body_parts = []
+        patient_birthday = None
+        patient_ages = list([])
+        patient_sex = None
+        adquisition_date_time = None
+        for session_path in Path(subject_path).glob('ses-*/'):
+            # if not session_path.match("ses-*"): continue
+            session = session_path.parts[-1]
+            session_id = session.split("-")[-1]
+
+            report = radiology_reports_dict.get(int(subject_id), {}).get("report", "n/a")
+            report = re.sub(r'[^\w\s\d\t]|[\n]', '', report) if report != "n/a" else "n/a"
+            scans_information = []
+
+            for json_pathfile in session_path.glob('**/*.json'):
+                note_path = json_pathfile.parent.joinpath(json_pathfile.stem + ".txt")
+                note = ""
+                if note_path.exists():
+                    with note_path.open('r') as file_:
+                        note = file_.read()
+                    note_path.unlink()
+                    if not note:
+                        logging.info(f"empty note : {note_path}")                        # raise FileNotFoundError
+                else:
+                    logging.info(f"notes not found for {subject}-{session}")
+
+                chunk_search = chunk_pattern.search(json_pathfile.stem)
+                if chunk_search:
+                    list_nifties = json_pathfile.parent.glob(
+                        chunk_pattern.sub(
+                            "*",
+                            json_pathfile.stem
+                        ) + "*"
+                    )
+                else:
+                    list_nifties = json_pathfile.parent.glob(
+                        json_pathfile.stem + "*"
+                    )
+
+                list_nifties = [f for f in list_nifties if ".nii" in f.suffixes]
+                logging.info(json_pathfile)
+                json_file = load_json(json_pathfile)
+                #print(json_file)
+                pseudo_id = subject #json_file.get("PatientID", {"Value": []}).get("Value"))
+                modality = json_file.get("Modality", {}).get("Value", ["n/a"])[0]
+
+                modalities.append(modality) #'[participants_keys[0]])
+
+                body_parts.append(
+                    json_file.get("BodyPartExamined", {}).get("Value", dataset_info.get("BodyPartExamined", ["n/a"]))[0] )
+
+                patient_birthday = json_file.get("PatientBirthDate", { }).get("Value", [""])[0]
+
+                try:
+                    patient_birthday = datetime.fromisoformat(patient_birthday) if patient_birthday else "n/a"
+                except ValueError:
+                    patient_birthday = datetime.fromisoformat(f"{patient_birthday[0:4]}-{patient_birthday[4:6]}-{patient_birthday[6:8]}") if patient_birthday else "n/a"
+                patient_sex = json_file.get("PatientSex", {"Value": ["n/a"]}).get("Value", ["n/a"])[0]
+
+                acquisition_date = json_file.get("AcquisitionDate",{}).get("Value", ["n/a"])[0]
+                if acquisition_date == "n/a" or acquisition_date == "":
+                    acquisition_date = json_file.get("StudyDate",{}).get("Value", [""])[0]
+                    acquisition_date = datetime.strptime(acquisition_date, "%Y%m%d%H%M%S.%f") if acquisition_date else  "n/a"
+
+                age = json_file.get("PatientAge", {}).get("Value", ["n/a"])[0]
+
+                if patient_birthday != "n/a" and acquisition_date != "n/a":
+                    age = int((acquisition_date - patient_birthday).days / (365.25))
+                #strip the numeric string   from the age
+                if age != "n/a":
+                    age = int( re.sub(r'\D', '', age)) #if age != "n/a" else int(age)
+                    patient_ages.append(age)
+
+                if modality == 'MR':
+                    for nifti in list_nifties:
+                        values = [json_file.get(key, {}).get('Value', ['n/a']) for key in scans_header_mr[2:]]
+                        scans_information.append({
+                            key: value
+                            for key, value in zip(
+                                scans_header_mr,
+                                [
+                                    str(nifti.relative_to(session_path)),
+                                    body_parts[-1],
+                                    # todo: find a way to unpack the list of values
+                                    *[item[0] if len(item) == 1 else item for item in values],
+                                    #*[json_file.get(key, {}).get('Value', ['n/a'])[:2] for key in scans_header_mr[2:]],
+                                    note
+                                ]
+                            )
+                        })
+                if modality in ["OP", "SC", "XC", "OT"]:
+                    for nifti in list_nifties:
+                        scans_information.append({
+                            key: value
+                            for key, value in zip(
+                                scans_header_op,
+                                [
+                                    str(nifti.relative_to(session_path)),
+                                    body_parts[-1],
+                                    *[json_file.get(key, {}).get('Value', ['n/a'])[0] for key in scans_header_op[2:-1]],
+                                    note
+                                ]
+                            )
+                        })
+                if modality in ["SM"]:
+                    for nifti in sorted(list_nifties):
+                        scans_information.append({
+                            key: value
+                            for key, value in zip(
+                                scans_header_micr,
+                                [
+                                    str(nifti.relative_to(session_path)),
+                                    body_parts[-1],
+                                    *[json_file.get(key_, "n/a") for key_ in scans_header_micr[2:]],
+                                    note
+                                ]
+                            )
+
+                        })
+
+            patient_ages = sorted(list(set(patient_ages)))
+            modalities = sorted(list(set(modalities)))
+            body_parts = sorted(list(set(body_parts)))
+            if Path(json_pathfile).exists():  # write
+                study_uid = json_file.get('StudyInstanceUID', {}).get('Value', ['n/a'])[0]
+            else:
+                study_uid = "n/a"
+
+            sessions_information.append({
+                k: v
+                for k, v in zip(
+                    session_header,
+                    [session, study_uid, acquisition_date.isoformat() if acquisition_date != "n/a" else "n/a" , report]
+                )
+
+            })
+            scans_df = pd.DataFrame.from_dict(scans_information)
+            scans_df = scans_df.replace('n/a', np.nan).dropna(axis=1, how='all')
+
+            scans_df.replace( np.nan,'n/a').to_csv(
+                session_path.joinpath(f"{subject}_{session}_scans.tsv"), sep="\t", index=False
+            )
+            save_json({ k:v for k,v in SCANS_MR_FIELDS.items() if k in scans_df.columns},
+                      filename=f"{subject}_{session}_scans.json", path=session_path)
+
+        sessions_df = pd.DataFrame.from_dict(sessions_information)#.replace('n/a', np.nan).dropna(axis=1, how='all')
+        sessions_df.replace( np.nan,'n/a').to_csv(
+            subject_path.joinpath(f"{subject}_sessions.tsv"), sep="\t", index=False
+        )
+        save_json(SESSION_FIELDS,
+                  filename=f"{subject}_sessions.json", path=subject_path)
+
+        pid_info = {
+            k: v
+            for k, v in zip(
+                participants_header,
+                [[subject], patient_ages, [patient_sex],  modalities, [','.join([f"{b}" for b in body_parts if  b])]]
+            )
+        }
+        #print(f"The body parts are: {body_parts}")
+        participants_information.append({k: (v[0] if v  else "n/a") for k, v in pid_info.items()})
+
+    participants_df = pd.DataFrame.from_dict(participants_information)
+    participants_df.to_csv(
+        data_path.joinpath("participants.tsv"), sep="\t", index=False
+    )
+
+    save_json(PARTICIPANTS_FIELDS,
+              filename = "participants.json", path = data_path)
+
+    return participants_information
+
+
+def  extract_nifti_metadata(file_path, body_part = 'LSPINE', modality = 'MR'):
+    tags = {
+        "Modality": {
+            "tag": "00080060",
+            "Value": [
+                f"{modality}"
+            ],
+            "vr": "CS"
+        },
+        "SeriesDescription": {
+            "tag": "0008103E",
+            "Value": [
+            ],
+            "vr": "LO"
+        },
+        "BodyPartExamined": {
+            "tag": "00180015",
+            "Value": [
+                " "
+            ],
+        "vr": "CS"
+    },
+    "PixelSpacing": {
+        "tag": "00280030",
+        "Value": [
+            1.0,
+            1.0
+        ],
+        "vr": "DS"
+    },
+    "SliceThickness": {
+        "tag": "00180050",
+        "Value": [
+            3
+        ],
+        "vr": "DS"
+    },
+    "ImageOrientationPatient": {
+        "tag": "00200037",
+        "Value": [
+            1,
+            0,
+            0,
+            0,
+            1,
+            0
+        ],
+        "vr": "DS"},
+    "SeriesDescription": {
+        "tag": "0008103E",
+        "Value": [
+            ""
+        ],
+        "vr": "LO"},
+    }
+    try:
+        tags = create_metadata_dict(body_part, file_path, modality, tags)
+    except Exception as e:
+        sitk.WriteImage( sitk.ReadImage(str(file_path)) , str(file_path) )
+        logging.info(f"Image saved as {file_path}")
+        try:
+            tags = create_metadata_dict(body_part, file_path, modality, tags)
+        except Exception as e:
+            logging.error(f"Error extracting metadata from {file_path}: {e}")
+            return tags
+    return tags
+
+
+def create_metadata_dict(body_part, file_path, modality, tags):
+    # Load the NIfTI file
+    nifti_image = nib.load(file_path)
+    # Access the header of the NIfTI file
+    header_dict = dict(nifti_image.header)
+    # Extract the metadata from the header
+    tags["Modality"]["Value"] = [modality]
+    tags["SeriesDescription"]["Value"] = [(header_dict.get("descrip", "").tobytes().decode('utf-8').strip('\x00'))]
+    tags["BodyPartExamined"]["Value"] = [body_part] if body_part else [""]
+    tags["PixelSpacing"]["Value"] = header_dict.get("pixdim", [1.0, 1.0, 1.0])[1:3].tolist()
+    tags["SliceThickness"]["Value"] = [header_dict.get("pixdim", [1.0, 1.0, 1.0])[3].tolist()]
+    tags["ImageOrientationPatient"]["Value"] = list(header_dict.get("srow_x", [1, 0, 0])[:3].tolist()) + list(
+        header_dict.get("srow_y", [0, 1, 0])[:3].tolist())
+    tags["SeriesDescription"]["Value"] = [header_dict.get("descrip", "").tobytes().decode('utf-8').strip('\x00')]
+    return tags
+
+
+
+def create_mids_filename(subject_id, session_id, metadata_lists =  {'BodyPartExamined': ['LSPINE'],
+                                                                          'Dimension': [''],
+                                                                          'ImagePlane': ['sag'],
+                                                                          'ModalityType': ['T2w']}, **kwargs
+                         ): # Default metadata values
+
+    """
+    Creates the BIDS-compatible filename for a given subject, session, body part, acquisition, run, and image plane.
+
+    Parameters:
+    - subject_id: The subject ID as a string.
+    """
+    body_part = kwargs.get('BodyPartExamined', metadata_lists.get('BodyPartExamined', [''])[0]) .lower()
+    acquisition = kwargs.get('Acquisition', metadata_lists.get('Acquisition', [''])[0])
+    dimension = kwargs.get('Dimension', metadata_lists.get('Dimension', [''])[0])
+    acquisition = f'{dimension}-{acquisition}' if dimension else acquisition
+    acquisition = acquisition[1:] if acquisition.startswith('-') else acquisition
+    image_plane = kwargs.get('ImagePlane', metadata_lists.get('ImagePlane', [''])[0]).lower()
+    modality_type = kwargs.get('ModalityType', metadata_lists.get('ModalityType', [''])[0])
+
+    series_number = 1
+    filename = f"sub-{subject_id}_ses-{session_id:02d}_bp-{body_part}_acq-{acquisition}_run-{series_number:02d}_vp-{image_plane[:3]}_{modality_type}.nii.gz"
+    return filename
+
+def segmentation_mids_filename(subject_id, session_id,  series_number = 1, **kwargs ): # Default metadata values
+
+    """
+    Creates the BIDS-compatible filename for a given subject, session, body part, acquisition, run, and image plane.
+
+    Parameters:
+    - subject_id: The subject ID as a string.
+    """
+    filename = f"sub-{subject_id}_ses-{session_id:02d}"
+    if 'BodyPartExamined' in kwargs:
+        filename += f"_bp-{kwargs['BodyPartExamined'].lower()}"
+    if 'Acquisition' in kwargs:
+        filename += f"_acq-{kwargs['Acquisition']}"
+    if 'Description' in kwargs:
+        filename += f"_desc-{kwargs['Description']}"
+    if 'Space' in kwargs:
+        filename += f"_space-{kwargs['Space']}"
+    filename += f"_run-{series_number:02d}"
+    if 'ImagePlane' in kwargs:
+        filename += f"_vp-{kwargs['ImagePlane'][:3]}"
+    if 'ModalityType' in kwargs:
+        filename += f"_mod-{kwargs['ModalityType']}"
+
+    filename += "_dseg.nii.gz"
+
+    return filename
+
+
+def convert_dicom_to_nifti(dicomdir: [Path | str], bidsdir: [Path | str], pidp: str = "ID") -> None:
+    """
+    Convert DICOM files in a directory to NIFTI format and organize them in a BIDS directory.
+
+    Parameters:
+    ----------
+    dicomdir: str
+        Path to the directory containing the DICOM files.
+    bidsdir: str
+        Path to the BIDS directory where the NIFTI files will be stored.
+    pidp: str
+      Prefix for the participant ID.
+
+    Returns:
+    -------
+        None
+
+    This function converts DICOM files in a directory to NIFTI format using the dcm2niix tool.
+    The converted NIFTI files are organized in a BIDS directory structure. The function
+    iterates over each subject directory in the DICOM directory and for each subject, it
+    creates a BIDS session directory. Within each session directory, it converts the DICOM
+    files to NIFTI format and copies the corresponding JSON metadata file. The function
+    handles multiple sessions per subject and creates separate session directories for each
+    """
+    dicomdir_path = Path(dicomdir)
+    bidsdir_path = Path(bidsdir)
+    tmpdir_path = bidsdir_path / 'derivatives' / 'nifti'
+    tmpdir_path.mkdir(parents=True, exist_ok=True)
+    for pdir in sorted(dicomdir_path.glob('*')):
+        if pdir.is_dir():
+            id =extract_number(pdir.name)
+            pid = f"{pidp}{int(id):03d}"
+            print(f" ------------------------------- ")
+            print(f"Processing subject ID {id} into {pid}")
+            print(f" ------------------------------- ")
+
+            ses = 1
+            for sesid in pdir.glob('*'):
+                ses_dir = tmpdir_path / f'sub-{pid}' / f'ses-{ses:02d}'
+                ses_dir.mkdir(parents=True, exist_ok=True)
+
+                for sid in sesid.glob('*'):
+                    (ses_dir / sid.name).mkdir(parents=True, exist_ok=True)
+                    if sid.is_dir():
+
+                        # Run dcm2niix and capture its output
+                        command = [
+                            'dcm2niix', '-b', 'n', '-z', 'y', '-m', 'y',
+                            '-f', f'sub-{pid}_ses-{ses}_%c',
+                            '-o', f'{(ses_dir/sid.name).as_posix()}',
+                            str(sid)
+                        ]
+
+                        result = subprocess.run(command, capture_output=True, text=True)
+                        output = result.stdout
+
+                        # Check if the conversion was successful
+                        if result.returncode != 0:
+                            logging.error(f"Error converting DICOM files to NIFTI format: {result.stderr}")
+                            continue
+
+                        # Short only the MR files
+                        for f in (ses_dir/sid.name).glob('*mod-MR-*.nii.gz'):
+
+                            # Retrieve the modality as the last part of the file segment splited by '_' before the extension
+                            modality =  f.stem.split('.')[0].split('_')[-1].split('-')[-1]
+                            for m, mtype in MODALITIES.items():
+                                if modality in mtype:
+                                    fname = f.name.replace('mod-MR-', f'')
+                                    if 'Eq_' in fname:
+                                        # Check if the file name matches the Equidistant resampled pattern
+                                        fname = re.sub( r'_Eq_[1-9]', '', fname).replace(r'_run', '_desc-equidistant_run')
+
+                                    fname = re.sub(r'_Eq.*', '.nii.gz', fname)
+                                    mod_dir =  bidsdir_path / f'sub-{pid}' / f'ses-{ses:02d}' / f'mr-{m}'
+                                    mod_dir.mkdir(parents=True, exist_ok=True)
+
+                                    f.replace(mod_dir /fname)
+                                    # Copy the extracted metadata from the dicom directory
+                                    json_source = sid / f"{sid.name}.json"
+                                    if json_source.exists():
+                                        #json_source.replace(mod_dir / f"{Path(Path(fname).stem).with_suffix('.json')}")
+                                        shutil.copy2(json_source, mod_dir / f"{Path(Path(fname).stem).with_suffix('.json')}")
+                ses += 1
+    # Cleanup
+    subprocess.run(['rm', '-r', '-f', str(tmpdir_path)])

--- a/src/ormir_mids/utils/files.py
+++ b/src/ormir_mids/utils/files.py
@@ -1,0 +1,123 @@
+# Copyright (c) Maria Monzon
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file_metadata except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+__author__ = "Maria Monzon"
+__version__ = "0.1.0"
+
+from typing import Optional, Union
+from pathlib import Path
+import json
+import numpy as np
+import logging
+import yaml
+
+
+def deserialize_dict(data: dict) -> dict:
+    """ Deserialize a dictionary to convert it to a JSON compatible dictionary
+
+    Parameters
+    ----------
+    data: str
+        JSON Object serialized as a string.
+
+    Returns
+    ----------
+    json_dict: dict
+        Python object loaded be serialized into a JSON Object.
+    """
+    dict = {}
+
+    class NumpyEncoder(json.JSONEncoder):
+        """
+        A method to handle default encoding for objects not serializable.
+
+        Parameters:
+            obj: The object to be encoded.
+
+        Returns:
+            The encoded object in a serializable format.
+        """
+
+        def default(self, obj):
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            return json.JSONEncoder.default(self, obj)
+
+    json_str = json.dumps(data, cls=NumpyEncoder)
+
+    return json.loads(json_str)
+
+
+def save_json(data: object, filename: [str,Path],  path: Optional[Union[str,Path]]='', sort: Optional[bool]=False)-> None:
+    """ Save a Python Object as JSON series_description fname
+
+    Parameters
+    ----------
+    data: Object
+        Python object loaded be serialized into a JSON Object.
+    filename: str, Path
+        File name of JSON fname we want to load.
+    path: str, Path
+        Target dicom_dir Path where to save the fname
+    sort: bool
+        Sort the keys of the JSON Object
+    """
+
+    fp = Path(path) / Path(filename).with_suffix('.json')
+    fp.parent.mkdir(exist_ok=True, parents=True)
+    try:
+        with open(fp, 'w', encoding='UTF-8') as f:
+            json.dump(data, f, sort_keys = sort, indent = 4, ensure_ascii = False)
+    except:
+        data = deserialize_dict(data)
+        with open(fp, 'w', encoding='UTF-8') as f:
+            json.dump(deserialize_dict(data), f, sort_keys = sort, indent = 4, ensure_ascii = False)
+
+
+def load_yaml(filepath: [str, Path]) -> object:
+    """ Load a Python Object with from  a YAML fname .yaml
+
+    Parameters
+    ----------
+    filepath: str, Path
+        File name of the fname we want to save.
+    path: str, Path
+        Target dicom_dir path where to save the fname
+    Returns
+    ----------
+    image_slice: Object
+        Python object loaded be serialized into a YAML stream.
+    """
+    data = object()
+    try:
+        with open(filepath, 'r') as fd:
+            return yaml.safe_load(fd)
+    except:
+        logging.exception(f"The yaml file {filepath} could not be loaded")
+    return data
+
+def save_yaml(data: object, filename: [str,Path], path: Optional[Union[str,Path]]='')-> None:
+    """ Save a Python Object with to disk in .yaml
+
+    Parameters
+    ----------
+    data: Object
+          Python objects to be serialized into a YAML stream.
+    filename: str, Path
+        File name of the fname we want to save.
+    path: str, Path
+        Target dicom_dir path where to save the fname
+    """
+    fp = Path(path) / Path(filename).with_suffix('.yaml')
+    fp.parent.mkdir(exist_ok=True, parents=True)
+    with open(fp, 'w') as f:
+        yaml.safe_dump(data, f, sort_keys=False)

--- a/src/ormir_mids/utils/files.py
+++ b/src/ormir_mids/utils/files.py
@@ -57,6 +57,26 @@ def deserialize_dict(data: dict) -> dict:
     return json.loads(json_str)
 
 
+
+def load_json(filepath: [str, Path]) -> object:
+    """ Load a JSON Object compressed as a binary fname or path
+
+    Parameters
+    ----------
+    filepath: str, Path
+        File name of JSON fname we want to load.
+
+    Returns
+    ----------
+    image_slice: Object
+        Python object loaded be serialized into a JSON Object.
+    """
+    try :
+        with open(filepath, 'rt', encoding='UTF-8') as f:
+            return json.load(f)
+    except:
+        return dict()
+
 def save_json(data: object, filename: [str,Path],  path: Optional[Union[str,Path]]='', sort: Optional[bool]=False)-> None:
     """ Save a Python Object as JSON series_description fname
 

--- a/src/ormir_mids/utils/strings.py
+++ b/src/ormir_mids/utils/strings.py
@@ -58,3 +58,20 @@ def remove_nonalphanumeric(text: str):
     except:
         text = ''
     return text
+
+
+def extract_number(filename, pattern ='\\d+', default=0):
+    """
+    Extracts the first number from the file path using a regular expression.
+
+    Parameters:
+    - file_path: The path of the file as a string.
+
+    Returns:
+    - The extracted case number as a string, zero-padded to three digits.
+    """
+    # Regex pattern to find the first number followed by one or more digits
+    match = re.search(pattern, filename)
+    if match:
+        return str(match.group(0)).zfill(3)  # Zero-pad the case number to three digits
+    return str(default).zfill(3)  # Return a default value if no match is found

--- a/src/ormir_mids/utils/strings.py
+++ b/src/ormir_mids/utils/strings.py
@@ -1,0 +1,60 @@
+# Copyright (c) Maria Monzon
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file_metadata except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -*- coding: utf-8 -*-
+__author__ = "Maria Monzon"
+__version__ = "0.1.0"
+import re
+
+def remove_special_characters(text: str):
+    """
+    Keep only  the non-alphanumeric characters as well as _ + symbols
+
+    in the text to clean and standardize text, which makes searching files easier
+
+    Parameters
+    ----------
+    text: str
+        The text to clean
+    Returns
+    -------
+    text: str
+        The cleaned text
+    """
+    # clean and standardize series_description descriptions, which makes searching files easier
+    try:
+        text = re.sub('[^a-zA-Z0-9 _\+\* ]', '', text)
+    except:
+        text = ''
+    return text.upper()
+
+
+def remove_nonalphanumeric(text: str):
+    """
+    Keep only  the non-alphanumeric characters as well as spaces
+
+    in the text to clean and standardize text, which makes searching files easier
+
+    Parameters
+    ----------
+    text: str
+        The text to clean
+    Returns
+    -------
+    text: str
+        The cleaned text
+    """
+    # clean and standardize series_description descriptions, which makes searching files easier
+    try:
+        text = re.sub('[^a-zA-Z0-9]', '', text)
+    except:
+        text = ''
+    return text


### PR DESCRIPTION
The pipeline comprise in 3 steps with example scripts in src/ormir_mids/bin (#3)
I have also included some mri specific tags that I use to extract metadata into the mri directory (also feel free to rename/refactor)
1. dicomdir.py: the datasets are stored in the DICOMDIR structure by separating the different dicom series . Furthermore, metadata for sorting the sequences is also extracted and added in image comments and saved as a json file.
2. dicom2mids.py: converts the dicom imagesusing dicom2niix tool in DICOMDIR structure into nifties and extracts the json metadata. Also sorts the files in the corresponding folder an d creates a mids compliant name of the form:
 sub-01_ses-1_bp-LSPINE_acq-2D-fse_run-02_vp-sag_T2w.json
4. create_mids_tsvs.py: Once the files are sorted, retrospectively creates the corresponding tsv files of participants, scans, and sessions
