### PR TITLE
Add aimio-py integration for reading Scanco files.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     bidict
     scipy
     ormir-pyvoxel >= 0.0.10
+    aimio-py
 tests_require = 
     pytest
     zenodo-get==1.6.1

--- a/src/ormir_mids/converters/ct.py
+++ b/src/ormir_mids/converters/ct.py
@@ -228,8 +228,9 @@ class ScancoConverter(Converter):
             
         if 'SCANCO' not in str(get_raw_tag_value(med_volume, '00080070')[0]).upper():
              return False
-                    
-        return _test_ima_type(med_volume, "ORIGINAL")
+
+        # ISQ volumes are marked ORIGINAL, AIM volumes (derived from ISQ) are marked DERIVED
+        return _test_ima_type(med_volume, "ORIGINAL") or _test_ima_type(med_volume, "DERIVED")
 
     @classmethod
     def convert_dataset(cls, med_volume: MedicalVolume):

--- a/src/ormir_mids/utils/io.py
+++ b/src/ormir_mids/utils/io.py
@@ -1,9 +1,22 @@
 import json
 import os
+from collections import namedtuple
+from pathlib import Path
 
+from py_aimio import read_image as read_scanco_image
 from voxel import DicomReader, DicomWriter, NiftiReader, NiftiWriter
+
 from ..utils import headers
 
+
+# Convenience tuple to hold an image (numpy.ndarray) and metadata (dict).
+numpy_image_tuple = namedtuple("NumpyImageTuple", ["image", "metadata"])
+# file extensions compatible with aimio-py
+scanco_file_extensions = [".isq", ".aim", ".scv", ".gobj"]
+
+
+class UnsupportedScancoExtensionError(ValueError):
+    """Custom error raised when a Scanco file has an extension not handled by `load_scanco`."""
 
 def load_dicom(path, group_by = None):
     """
@@ -194,3 +207,38 @@ def find_omids(path, suffix):
                 found_files.append(os.path.join(root, f))
 
     return found_files
+
+def load_scanco(path, **kwargs):
+    """
+    Read a HR-pQCT (Scanco) AIM, ISQ, SCV, GOBJ image using the py_aimio library.
+
+    Parameters:
+        path (str or pathlib.Path): Path to the Scanco file to read. Strings
+            or path-like objects are accepted. VMS-style paths with a trailing
+            version suffix such as "scan.AIM;3" are supported.
+        **kwargs: Additional keyword arguments passed to read_scanco_image.
+
+    Returns:
+        NumpyImageTuple (tuple): A tuple-like object containing the loaded image array and its
+            associated metadata as (numpy.ndarray, dict).
+    """
+    # check if the input file path is a `Path` object, if not convert it to a `Path` object
+    if not isinstance(path, Path):
+        path = Path(path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Input file {path} does not exist.")
+
+    # Get the file extension and check if it's readable. VMS-style paths may carry
+    # a trailing version number (e.g. "scan.AIM;3"), so strip that off before matching.
+    # The file itself is opened using the original, unmodified path.
+    input_extension = path.suffix.lower().split(";", 1)[0]
+
+    if input_extension in scanco_file_extensions:
+        image, metadata = read_scanco_image(path, **kwargs)
+    else:
+        raise UnsupportedScancoExtensionError(
+            f"Input file {path} has an unsupported file extension. Supported extensions are: {scanco_file_extensions}"
+        )
+
+    return numpy_image_tuple(image, metadata)

--- a/src/ormir_mids/utils/scanco.py
+++ b/src/ormir_mids/utils/scanco.py
@@ -1,0 +1,277 @@
+import datetime
+from pathlib import Path
+
+import numpy as np
+from py_aimio import (
+    get_aim_density_equation,
+    get_aim_hu_equation,
+    get_isq_density_equation,
+    get_isq_hu_equation,
+)
+
+from .io import load_scanco
+from .OMidsMedVolume import OMidsMedVolume as MedicalVolume
+
+# AIM's processing_log and ISQ's flat meta dict use different field names for the same
+# concepts, so patient-identifying and main-header fields are tracked per format. Anything
+# not in either set below ends up in extra_header.
+_AIM_PATIENT_LOG_KEYS = {
+    "Patient Name", "Index Patient", "Index Measurement", "Site", "Scanner ID",
+    "Original Creation-Date", "Time", "Original file",
+}
+_AIM_MAIN_LOG_KEYS = {
+    "Energy [V]", "Integration time [us]", "Intensity [uA]", "Reconstruction-Alg.",
+    "Mu_Scaling", "HU: mu water", "Density: slope", "Density: intercept",
+}
+_ISQ_PATIENT_KEYS = {
+    "name", "patient_index", "index_measurement", "site", "scanner_id",
+    "creation_date", "creation_date_string",
+}
+_ISQ_MAIN_KEYS = {
+    "energy", "sampletime_us", "intensity", "recon_alg", "mu_scaling", "mu_water",
+    "rescale_slope", "rescale_intercept",
+}
+
+_SCANCO_DATE_FORMATS = ("%d-%b-%Y", "%Y-%m-%d")
+
+
+def _num(value, default=0.0):
+    """ Best-effort float conversion, falling back to a default instead of raising """
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value, default=0):
+    """ Best-effort int conversion, falling back to a default instead of raising """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def jsonable(value):
+    """ Coerces aimio-py metadata (numpy scalars, tuples, nested dicts) into something json.dump can handle
+
+    Parameters:
+        value (Any): the value to coerce
+
+    Returns:
+        Any: a value made only of dict/list/str/int/float/bool/None
+    """
+    if isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, (int, float, str, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [jsonable(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): jsonable(v) for k, v in value.items()}
+    return str(value)
+
+
+def _is_aim_meta(meta):
+    """ Distinguishes AIM metadata (nested under processing_log) from flat ISQ metadata """
+    return "processing_log" in meta
+
+
+def _scanco_date(value):
+    """ Normalizes a Scanco date string to DICOM-style YYYYMMDD
+
+    Handles AIM's "14-SEP-2016 15:27:12.18" and ISQ's " 8-MAY-2026 10:03:52.03\\n", both of
+    which carry the date as the first whitespace-separated token.
+
+    Parameters:
+        value (Any): the raw date value from Scanco metadata
+
+    Returns:
+        str: the date as YYYYMMDD, or an empty string if it could not be parsed
+    """
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    token = text.split()[0]
+    for fmt in _SCANCO_DATE_FORMATS:
+        try:
+            return datetime.datetime.strptime(token, fmt).strftime("%Y%m%d")
+        except ValueError:
+            continue
+    return ""
+
+
+_MICRON_TO_MM = 1e-3
+
+
+def _scanco_affine(meta):
+    """ Builds a 4x4 affine from the geometry aimio-py already computes (DICOM/LPS convention, no ITK needed)
+
+    aimio-py's AIM reader reports spacing/origin in millimeters, but its ISQ reader reports
+    them in micrometers (verified against real files: ISQ spacing equals dimensions_um /
+    dimensions, unconverted). Both are normalized to millimeters here.
+
+    Parameters:
+        meta (dict): Scanco metadata, as returned by load_scanco
+
+    Returns:
+        np.ndarray: a 4x4 affine matrix, in millimeters
+    """
+    spacing = np.asarray(meta["spacing"], dtype=float)
+    origin = np.asarray(meta["origin"], dtype=float)
+    if not _is_aim_meta(meta):
+        spacing = spacing * _MICRON_TO_MM
+        origin = origin * _MICRON_TO_MM
+    direction = np.asarray(meta["direction"], dtype=float).reshape(3, 3)
+    affine = np.eye(4)
+    affine[:3, :3] = direction @ np.diag(spacing)
+    affine[:3, 3] = origin
+    return affine
+
+
+def _build_main_header(meta):
+    """ Builds the omids_header: fields needed for a good conversion, mirroring what
+    ScancoConverter.convert_dataset (converters/ct.py) expects
+
+    Parameters:
+        meta (dict): Scanco metadata, as returned by load_scanco
+
+    Returns:
+        dict: the omids_header
+    """
+    header = {
+        "Modality": "CT",
+        "Manufacturer": "SCANCO Medical",
+    }
+
+    if _is_aim_meta(meta):
+        log = meta.get("processing_log", {})
+        header["ImageTypeSiemens"] = "DERIVED/PRIMARY/AXIAL"
+        header["XRayEnergy"] = _num(log.get("Energy [V]")) / 1000.0
+        header["XRayExposureTime"] = _num(log.get("Integration time [us]")) / 1000.0
+        header["XRayExposure"] = (
+            _num(log.get("Intensity [uA]")) * _num(log.get("Integration time [us]")) / 1e6
+        )
+        header["ConvolutionKernel"] = str(log.get("Reconstruction-Alg.", ""))
+        header["ScancoMuScaling"] = _int(log.get("Mu_Scaling"))
+        header["ScancoMuWater"] = _num(log.get("HU: mu water"))
+        processing_log_raw = meta.get("processing_log_raw", "")
+        rescale_slope, rescale_intercept = get_aim_hu_equation(processing_log_raw)
+        density_slope, density_intercept = get_aim_density_equation(processing_log_raw)
+    else:
+        header["ImageTypeSiemens"] = "ORIGINAL/PRIMARY/AXIAL"
+        header["XRayEnergy"] = _num(meta.get("energy")) / 1000.0
+        header["XRayExposureTime"] = _num(meta.get("sampletime_us")) / 1000.0
+        header["XRayExposure"] = (
+            _num(meta.get("intensity")) * _num(meta.get("sampletime_us")) / 1e6
+        )
+        header["ConvolutionKernel"] = str(meta.get("recon_alg", ""))
+        header["ScancoMuScaling"] = _int(meta.get("mu_scaling"))
+        header["ScancoMuWater"] = _num(meta.get("mu_water"))
+        rescale_slope, rescale_intercept = get_isq_hu_equation(meta)
+        density_slope, density_intercept = get_isq_density_equation(meta)
+
+    # Voxels stay in native units. RescaleSlope/RescaleIntercept give the standard DICOM
+    # CT conversion to Hounsfield Units; ScancoDensitySlope/ScancoDensityIntercept give the
+    # Scanco-specific conversion to BMD (no DICOM-standard equivalent).
+    header["RescaleSlope"] = rescale_slope
+    header["RescaleIntercept"] = rescale_intercept
+    header["ScancoDensitySlope"] = density_slope
+    header["ScancoDensityIntercept"] = density_intercept
+    return header
+
+
+def _build_patient_header(meta):
+    """ Builds the patient_header: identifying and scan-location fields, kept out of
+    omids_header/extra_header so they can be excluded from output independently
+    (save_patient_json=False)
+
+    Parameters:
+        meta (dict): Scanco metadata, as returned by load_scanco
+
+    Returns:
+        dict: the patient_header
+    """
+    if _is_aim_meta(meta):
+        log = meta.get("processing_log", {})
+        header = {
+            "PatientName": str(log.get("Patient Name", "")).strip(),
+            "PatientID": str(log.get("Index Patient", "")),
+            "ScancoMeasurementIndex": str(log.get("Index Measurement", "")),
+            "ScancoSite": str(log.get("Site", "")),
+            "ScannerID": str(log.get("Scanner ID", "")),
+            "ScanDate": _scanco_date(log.get("Original Creation-Date") or log.get("Time")),
+        }
+        original_file = log.get("Original file")
+        if original_file:
+            header["OriginalFile"] = str(original_file)
+        return header
+
+    return {
+        "PatientName": str(meta.get("name", "")).strip(),
+        "PatientID": str(meta.get("patient_index", "")),
+        "ScancoMeasurementIndex": str(meta.get("index_measurement", "")),
+        "ScancoSite": str(meta.get("site", "")),
+        "ScannerID": str(meta.get("scanner_id", "")),
+        "ScanDate": _scanco_date(meta.get("creation_date_string")),
+    }
+
+
+def _build_extra_header(meta):
+    """ Builds the extra_header: remaining technical metadata, minus fields promoted to
+    omids_header/patient_header and minus leak vectors (`filename` is a full local path;
+    `processing_log_raw` duplicates patient fields as plain text even after the parsed
+    processing_log dict is scrubbed)
+
+    Parameters:
+        meta (dict): Scanco metadata, as returned by load_scanco
+
+    Returns:
+        dict: the extra_header, safe to json.dump
+    """
+    if _is_aim_meta(meta):
+        extra = {
+            k: v for k, v in meta.items()
+            if k not in ("filename", "processing_log", "processing_log_raw")
+        }
+        extra["processing_log"] = {
+            k: v for k, v in meta.get("processing_log", {}).items()
+            if k not in _AIM_PATIENT_LOG_KEYS and k not in _AIM_MAIN_LOG_KEYS
+        }
+    else:
+        extra = {
+            k: v for k, v in meta.items()
+            if k not in _ISQ_PATIENT_KEYS and k not in _ISQ_MAIN_KEYS and k != "filename"
+        }
+    return jsonable(extra)
+
+
+def scanco_volume_to_mids(path, **kwargs):
+    """
+    Reads a Scanco AIM/ISQ/SCV/GOBJ file and builds an OMidsMedVolume from it.
+
+    Parameters:
+        path (str or pathlib.Path): Path to the Scanco file.
+        **kwargs: Additional keyword arguments passed to load_scanco (e.g. unit="hu" for
+            ISQ, density=True for AIM).
+
+    Returns:
+        OMidsMedVolume: the volume, with omids_header, patient_header, extra_header and
+            meta_header populated.
+    """
+    image, meta = load_scanco(path, **kwargs)
+    volume = np.transpose(image, (2, 1, 0))  # (z,y,x) -> (x,y,z), no flip needed
+    affine = _scanco_affine(meta)
+
+    med_volume = MedicalVolume(volume, affine)
+    med_volume.path = str(path)
+    med_volume.omids_header = _build_main_header(meta)
+    med_volume.bids_header = med_volume.omids_header
+    med_volume.patient_header = _build_patient_header(meta)
+    med_volume.extra_header = _build_extra_header(meta)
+    med_volume.meta_header = {
+        "SourceFormat": "SCANCO",
+        "SourceFile": Path(path).name,
+    }
+    return med_volume

--- a/test/test_scanco_ct.py
+++ b/test/test_scanco_ct.py
@@ -5,6 +5,13 @@ import numpy as np
 import pytest
 from helpers import check_nib_shape, zenodo_download_and_extract
 
+from py_aimio import (
+    get_aim_density_equation,
+    get_aim_hu_equation,
+    get_isq_density_equation,
+    get_isq_hu_equation,
+)
+
 from ormir_mids.converters.ct import ScancoConverter
 from ormir_mids.dcm2omids import convert_dicom_to_ormirmids
 from ormir_mids.utils.io import (
@@ -14,6 +21,7 @@ from ormir_mids.utils.io import (
     scanco_file_extensions,
 )
 from ormir_mids.utils.OMidsMedVolume import OMidsMedVolume
+from ormir_mids.utils.scanco import _scanco_affine, jsonable, scanco_volume_to_mids
 
 
 @pytest.fixture(scope="session")
@@ -238,3 +246,274 @@ def first_scanco_image_path(scanco_raw_data_dir):
         f"Contents: {list(scanco_raw_data_dir.rglob('*'))}"
     )
     return candidates[0]
+
+
+# --- scanco_volume_to_mids: field-to-file split -----------------------------------------
+#
+# Metadata below mirrors real py_aimio output (captured by reading actual .AIM/.ISQ files),
+# with patient-identifying values replaced by fakes. Two real-world quirks are preserved
+# deliberately, since they drive behavior in scanco_volume_to_mids:
+#   - AIM nests most fields under processing_log; ISQ has them flat.
+#   - AIM's spacing is in millimeters; ISQ's is in micrometers (unconverted by py_aimio).
+
+_AIM_ARRAY_SHAPE = (2, 3, 4)  # (z, y, x), matching dimensions (4, 3, 2) below
+
+
+def _aim_meta():
+    processing_log_raw = (
+        "! Processing Log\n"
+        "!\n"
+        "Created by                    ISQ_TO_AIM (IPL)\n"
+        "Time                          16-APR-2017 20:20:59.67\n"
+        "Original file                 dk0:[xtremect2.data.00001237.00005697]d0005679.isq;\n"
+        "Original Creation-Date        14-SEP-2016 15:27:12.18\n"
+        "Patient Name                                   DBQ_152\n"
+        "Index Patient                                     1237\n"
+        "Index Measurement                                5697\n"
+        "Site                                               20\n"
+        "Scanner ID                                       3401\n"
+        "Scanner type                                        9\n"
+        "Reconstruction-Alg.                                 3\n"
+        "Energy [V]                                      68000\n"
+        "Intensity [uA]                                   1470\n"
+        "Integration time [us]                           43000\n"
+        "Mu_Scaling                                       8192\n"
+        "HU: mu water                                   0.2366\n"
+        "Density: slope                             1662.52405\n"
+        "Density: intercept                        -398.609009\n"
+    )
+    return {
+        "filename": "/home/user/private_study/00001237/IMG1237.AIM",
+        "version": 2,
+        "id": 0,
+        "reference": 0,
+        "aim_type": 131074,
+        "buffer_type": 2,
+        "position": (1069, 541, 0),
+        "dimensions": (4, 3, 2),
+        "offset": (0, 0, 0),
+        "element_size": (0.0607, 0.0607, 0.0607),
+        "processing_log": {
+            "Created by": "ISQ_TO_AIM (IPL)",
+            "Time": "16-APR-2017 20:20:59.67",
+            "Original file": "dk0:[xtremect2.data.00001237.00005697]d0005679.isq;",
+            "Original Creation-Date": "14-SEP-2016 15:27:12.18",
+            "Patient Name": "DBQ_152",
+            "Index Patient": 1237,
+            "Index Measurement": 5697,
+            "Site": 20,
+            "Scanner ID": 3401,
+            "Scanner type": 9,
+            "Reconstruction-Alg.": 3,
+            "Energy [V]": 68000,
+            "Intensity [uA]": 1470,
+            "Integration time [us]": 43000,
+            "Mu_Scaling": 8192,
+            "HU: mu water": 0.2366,
+            "Density: slope": 1662.52405,
+            "Density: intercept": -398.609009,
+            "Calibration Data": "68 kVp, BH: 200 mg HA/ccm, Scaling 8192, 0.2 CU",
+        },
+        "byte_offset": 3197,
+        "spacing": (0.0607, 0.0607, 0.0607),
+        "origin": (64.8879, 32.8385, 0.0),
+        "vtkbone_origin": (64.9183, 32.8689, 0.0303),
+        "direction": (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        "processing_log_raw": processing_log_raw,
+    }
+
+
+def _isq_meta():
+    return {
+        "filename": "/home/user/private_study/00347/C0004378.ISQ",
+        "version": 4,
+        "data_type": 3,
+        "nr_of_bytes": 1270877696,
+        "nr_of_blocks": 2482183,
+        "patient_index": 347,
+        "scanner_id": 6020,
+        "creation_date": (1872582144, 12304986),
+        "dimensions": (4, 3, 2),
+        "dimensions_p": (4, 3, 2),
+        "dimensions_um": (137.6, 103.2, 68.8),
+        "offset": (0, 0, 0),
+        "spacing": (34.4, 34.4, 34.4),  # micrometers, unconverted by py_aimio
+        "creation_date_string": " 8-MAY-2026 10:03:52.03\n",
+        "slice_thickness_um": 34,
+        "slice_increment_um": 34,
+        "slice_1_pos_um": 40713,
+        "min_data_value": -4111,
+        "max_data_value": 32767,
+        "mu_scaling": 4096,
+        "nr_of_samples": 1024,
+        "nr_of_projections": 250,
+        "scandist_um": 35225,
+        "scanner_type": 10,
+        "sampletime_us": 200000,
+        "index_measurement": 4559,
+        "site": 4,
+        "reference_line_um": 40713,
+        "recon_alg": 3,
+        "name": "BME_2026                               ",
+        "energy": 70000,
+        "intensity": 200,
+        "holder": 10,
+        "data_offset": 3584,
+        "buffer_type": 0,
+        "rescale_type": 1,
+        "rescale_units": "mg HA/ccm",
+        "rescale_slope": 373.335,
+        "rescale_intercept": -194.278,
+        "mu_water": 0.4792,
+        "origin": (0.0, 0.0, 0.0),
+        "direction": (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        "unit": "native",
+    }
+
+
+def _load_scanco_volume(meta, filename):
+    array = np.arange(np.prod(_AIM_ARRAY_SHAPE), dtype=np.int16).reshape(_AIM_ARRAY_SHAPE)
+    with mock.patch(
+        "ormir_mids.utils.scanco.load_scanco", return_value=(array, meta)
+    ):
+        return scanco_volume_to_mids(filename), array
+
+
+def test_scanco_volume_to_mids_transposes_without_flipping():
+    """volume[i,j,k] (x,y,z) must equal array[k,j,i] (z,y,x): a pure axis permutation, no reversal."""
+    med_volume, array = _load_scanco_volume(_aim_meta(), "scan.AIM")
+    assert med_volume.volume.shape == (4, 3, 2)
+    for i in range(4):
+        for j in range(3):
+            for k in range(2):
+                assert med_volume.volume[i, j, k] == array[k, j, i]
+
+
+def test_scanco_affine_aim_is_already_millimeters():
+    meta = _aim_meta()
+    affine = _scanco_affine(meta)
+    np.testing.assert_allclose(np.diag(affine)[:3], meta["spacing"])
+    np.testing.assert_allclose(affine[:3, 3], meta["origin"])
+
+
+def test_scanco_affine_isq_micrometers_converted_to_millimeters():
+    """Regression test: py_aimio reports ISQ spacing in micrometers, unlike AIM's millimeters.
+    Without conversion the affine would be 1000x too large."""
+    meta = _isq_meta()
+    affine = _scanco_affine(meta)
+    expected_spacing_mm = np.array(meta["spacing"]) * 1e-3
+    np.testing.assert_allclose(np.diag(affine)[:3], expected_spacing_mm)
+    assert np.diag(affine)[0] < 1.0  # ~0.0344 mm, not ~34.4
+
+
+def test_scanco_volume_to_mids_aim_field_split():
+    med_volume, _ = _load_scanco_volume(_aim_meta(), "IMG1237.AIM")
+
+    # main json: fields ScancoConverter.convert_dataset needs
+    processing_log_raw = _aim_meta()["processing_log_raw"]
+    expected_rescale_slope, expected_rescale_intercept = get_aim_hu_equation(processing_log_raw)
+    expected_density_slope, expected_density_intercept = get_aim_density_equation(processing_log_raw)
+    assert med_volume.omids_header == {
+        "Modality": "CT",
+        "Manufacturer": "SCANCO Medical",
+        "RescaleSlope": expected_rescale_slope,
+        "RescaleIntercept": expected_rescale_intercept,
+        "ImageTypeSiemens": "DERIVED/PRIMARY/AXIAL",
+        "XRayEnergy": 68.0,
+        "XRayExposureTime": 43.0,
+        "XRayExposure": pytest.approx(1470 * 43000 / 1e6),
+        "ConvolutionKernel": "3",
+        "ScancoMuScaling": 8192,
+        "ScancoMuWater": 0.2366,
+        "ScancoDensitySlope": expected_density_slope,
+        "ScancoDensityIntercept": expected_density_intercept,
+    }
+    assert isinstance(med_volume.omids_header["ScancoMuScaling"], int)
+
+    # patient json: identifying + location fields
+    assert med_volume.patient_header == {
+        "PatientName": "DBQ_152",
+        "PatientID": "1237",
+        "ScancoMeasurementIndex": "5697",
+        "ScancoSite": "20",
+        "ScannerID": "3401",
+        "ScanDate": "20160914",
+        "OriginalFile": "dk0:[xtremect2.data.00001237.00005697]d0005679.isq;",
+    }
+
+    # extra json: must not duplicate anything from main/patient, must not leak filename/raw log
+    extra = med_volume.extra_header
+    assert "filename" not in extra
+    assert "processing_log_raw" not in extra
+    for leaked_key in ("Patient Name", "Index Patient", "Index Measurement", "Site",
+                       "Scanner ID", "Original file", "Original Creation-Date", "Time",
+                       "Energy [V]", "Mu_Scaling", "Density: slope"):
+        assert leaked_key not in extra["processing_log"]
+    assert extra["processing_log"]["Calibration Data"] == "68 kVp, BH: 200 mg HA/ccm, Scaling 8192, 0.2 CU"
+    assert extra["element_size"] == [0.0607, 0.0607, 0.0607]
+    json.dumps(extra)  # must be json-safe
+
+    assert med_volume.meta_header == {"SourceFormat": "SCANCO", "SourceFile": "IMG1237.AIM"}
+
+
+def test_scanco_volume_to_mids_isq_field_split():
+    meta = _isq_meta()
+    med_volume, _ = _load_scanco_volume(meta, "C0004378.ISQ")
+
+    expected_rescale_slope, expected_rescale_intercept = get_isq_hu_equation(meta)
+    expected_density_slope, expected_density_intercept = get_isq_density_equation(meta)
+    assert med_volume.omids_header == {
+        "Modality": "CT",
+        "Manufacturer": "SCANCO Medical",
+        "RescaleSlope": expected_rescale_slope,
+        "RescaleIntercept": expected_rescale_intercept,
+        "ImageTypeSiemens": "ORIGINAL/PRIMARY/AXIAL",
+        "XRayEnergy": 70.0,
+        "XRayExposureTime": 200.0,
+        "XRayExposure": pytest.approx(200 * 200000 / 1e6),
+        "ConvolutionKernel": "3",
+        "ScancoMuScaling": 4096,
+        "ScancoMuWater": 0.4792,
+        "ScancoDensitySlope": expected_density_slope,
+        "ScancoDensityIntercept": expected_density_intercept,
+    }
+    assert isinstance(med_volume.omids_header["ScancoMuScaling"], int)
+
+    assert med_volume.patient_header == {
+        "PatientName": "BME_2026",
+        "PatientID": "347",
+        "ScancoMeasurementIndex": "4559",
+        "ScancoSite": "4",
+        "ScannerID": "6020",
+        "ScanDate": "20260508",
+    }
+    assert "OriginalFile" not in med_volume.patient_header  # ISQ has no such field
+
+    extra = med_volume.extra_header
+    assert "filename" not in extra
+    for leaked_key in ("name", "patient_index", "index_measurement", "site", "scanner_id",
+                        "creation_date", "creation_date_string", "energy", "sampletime_us",
+                        "mu_scaling", "mu_water", "rescale_slope", "rescale_intercept"):
+        assert leaked_key not in extra
+    assert extra["rescale_units"] == "mg HA/ccm"
+    assert extra["slice_thickness_um"] == 34
+    json.dumps(extra)
+
+    assert med_volume.meta_header == {"SourceFormat": "SCANCO", "SourceFile": "C0004378.ISQ"}
+
+
+def test_scanco_converter_accepts_aim_and_isq():
+    aim_volume, _ = _load_scanco_volume(_aim_meta(), "scan.AIM")
+    isq_volume, _ = _load_scanco_volume(_isq_meta(), "scan.ISQ")
+
+    assert ScancoConverter.is_dataset_compatible(aim_volume) is True
+    assert ScancoConverter.is_dataset_compatible(isq_volume) is True
+
+
+def test_jsonable_handles_numpy_scalars_tuples_and_nested_dicts():
+    payload = {"a": np.float32(1.5), "b": (1, 2, np.int64(3)), "c": {"d": None}}
+    result = jsonable(payload)
+    json.dumps(result)
+    assert result["a"] == pytest.approx(1.5)
+    assert result["b"] == [1, 2, 3]
+    assert result["c"] == {"d": None}

--- a/test/test_scanco_ct.py
+++ b/test/test_scanco_ct.py
@@ -1,9 +1,18 @@
-import pytest
 import json
-from ormir_mids.dcm2omids import convert_dicom_to_ormirmids
-from helpers import zenodo_download_and_extract, check_nib_shape
 import unittest.mock as mock
+
+import numpy as np
+import pytest
+from helpers import check_nib_shape, zenodo_download_and_extract
+
 from ormir_mids.converters.ct import ScancoConverter
+from ormir_mids.dcm2omids import convert_dicom_to_ormirmids
+from ormir_mids.utils.io import (
+    UnsupportedScancoExtensionError,
+    load_scanco,
+    numpy_image_tuple,
+    scanco_file_extensions,
+)
 from ormir_mids.utils.OMidsMedVolume import OMidsMedVolume
 
 
@@ -76,13 +85,15 @@ def test_download(downloaded_data):
 def test_convert(converted_data):
     """Test that conversion created the expected directory"""
     assert (
-        converted_data / 'sub-anon' / "ct"
-    ).exists(), f"Missing ct directory. Available directories: {list(converted_data.iterdir())}"
+        converted_data / "sub-anon" / "ct"
+    ).exists(), (
+        f"Missing ct directory. Available directories: {list(converted_data.iterdir())}"
+    )
 
 
 def test_json(converted_data):
     """Test the JSON metadata"""
-    omids_dir = converted_data / 'sub-anon' / "ct"
+    omids_dir = converted_data / "sub-anon" / "ct"
     assert (
         omids_dir / "sub-anon_hrpqct.json"
     ).exists(), f"JSON file not found. Directory contents: {list(omids_dir.iterdir())}"
@@ -96,7 +107,7 @@ def test_json(converted_data):
 
 def test_nii(converted_data):
     """Test the NIfTI file"""
-    omids_dir = converted_data / 'sub-anon' / "ct"
+    omids_dir = converted_data / "sub-anon" / "ct"
     nii_file = omids_dir / "sub-anon_hrpqct.nii.gz"
     assert (
         nii_file.exists()
@@ -134,3 +145,96 @@ def test_compatibility_detection():
         return_value=["Random Manufacturer"],
     ):
         assert ScancoConverter.is_dataset_compatible(mock_volume) is False
+
+
+def test_load_scanco_missing_file(tmp_path):
+    """A non-existent path should raise FileNotFoundError."""
+    missing = tmp_path / "missing.aim"
+    with pytest.raises(FileNotFoundError):
+        load_scanco(missing)
+
+
+def test_load_scanco_unsupported_extension(tmp_path):
+    """An unsupported extension should raise UnsupportedScancoExtensionError."""
+    bogus = tmp_path / "scan.xyz"
+    bogus.touch()
+    with pytest.raises(UnsupportedScancoExtensionError):
+        load_scanco(bogus)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["scan.aim", "scan.isq", "scout.scv", "mask.gobj", "scan.AIM"],
+)
+def test_load_scanco_reads_supported_extensions(tmp_path, filename):
+    """Any supported extension is forwarded to the single read_image dispatcher."""
+    scanco_file = tmp_path / filename
+    scanco_file.touch()
+    with mock.patch(
+        "ormir_mids.utils.io.read_scanco_image", return_value=("image", {"meta": 1})
+    ) as mocked_reader:
+        result = load_scanco(scanco_file)
+
+    mocked_reader.assert_called_once_with(scanco_file)
+    assert result == numpy_image_tuple("image", {"meta": 1})
+
+
+def test_load_scanco_passes_kwargs_through(tmp_path):
+    """Keyword arguments (e.g. density=True) must reach the underlying reader."""
+    aim_file = tmp_path / "scan.aim"
+    aim_file.touch()
+    with mock.patch(
+        "ormir_mids.utils.io.read_scanco_image", return_value=("image", {})
+    ) as mocked_reader:
+        load_scanco(aim_file, density=True)
+
+    mocked_reader.assert_called_once_with(aim_file, density=True)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["scan.aim;3", "scan.isq;12", "scout.scv;7", "mask.gobj;1", "scan.AIM;3"],
+)
+def test_load_scanco_versioned_vms_paths(tmp_path, filename):
+    """VMS-style paths carry a trailing `;<version>` suffix (e.g. "scan.aim;3").
+
+    The extension must be resolved for dispatch, and the file must be opened
+    using the original, unmodified path -- no renaming on disk.
+    """
+    versioned_file = tmp_path / filename
+    versioned_file.touch()
+
+    with mock.patch(
+        "ormir_mids.utils.io.read_scanco_image", return_value=("image", {})
+    ) as mocked_reader:
+        load_scanco(versioned_file)
+
+    mocked_reader.assert_called_once_with(versioned_file)
+    # The original, version-suffixed file must still be present. Nothing was renamed.
+    assert versioned_file.exists()
+
+
+@pytest.fixture(scope="session")
+def scanco_raw_data_dir(tmp_path_factory):
+    """Download the raw Scanco record (real, unconverted AIM/ISQ/SCV/GOBJ files)."""
+    data_dir = tmp_path_factory.mktemp("scanco_raw_data")
+    doi = r"https://doi.org/10.5281/zenodo.4073082"
+    zenodo_download_and_extract(doi, data_dir)
+    return data_dir
+
+
+@pytest.fixture(scope="session")
+def first_scanco_image_path(scanco_raw_data_dir):
+    """Locate the first Scanco-format file in the downloaded record, sorted by
+    path for a deterministic pick. VMS version suffixes (e.g. ";1") are
+    resolved with the same logic load_scanco itself uses."""
+    candidates = sorted(
+        p
+        for p in scanco_raw_data_dir.rglob("*")
+        if p.is_file() and p.suffix.lower().split(";", 1)[0] in scanco_file_extensions
+    )
+    assert candidates, (
+        f"No Scanco-format files found in {scanco_raw_data_dir}. "
+        f"Contents: {list(scanco_raw_data_dir.rglob('*'))}"
+    )
+    return candidates[0]


### PR DESCRIPTION
**Summary**

Added support for scanco formats (AIM/ISQ/SCV/GOBJ) to ormir-mids: reader integration and converter that builds a ormir-mids `MedicalVolume`, following same DICOM header conventions.

**Changes**

Reading (`utils/io.py`):

- `load_scanco()` reads .aim/.isq/.scv/.gobj files via py_aimio, handles VMS-style versioned paths (e.g., `example.AIM;3`) and raises clear errors for unsupported file formats
- Add `aimio-py` as a dependency

`MedicalVolume` construction (`utils/scanco.py`, new):

- `scanco_volume_to_mids(path, **kwargs)` builds the volume, affine transform, and headers from load_scanco()'s output
- Forces the same units between formats (ISQ is in µm, AIM in mm -> mm as default)
- Splits metadata across the three sidecar files so no identifying data ends up in the wrong place: acquisition/calibration fields (HU and BMD rescale, energy, kernel, etc.) in the main .json; patient name/ID/scan date/site in _patient.json; the rest in _extra.json

**Testing**

- `test/test_scanco_ct.py` adds unit tests covering the implemented code using real metadata copied from actual anonymized Scanco AIMs/ISQs. SCVs and GOBJs remain untested for now.

**Follow-ups**

- Include automatic detection and conversion of Scanco images like in `dcm2omids`
- Thorough anonymization tests as per GCP recommendation
- SCV/GOBJ not yet verified with real files
